### PR TITLE
Fixed url's missing prefix

### DIFF
--- a/src/main/java/net/darkhax/cursedata/Project.java
+++ b/src/main/java/net/darkhax/cursedata/Project.java
@@ -238,7 +238,7 @@ public class Project {
 
     public String getProjectUrl () {
 
-        return this.projectUrl;
+        return "https:" + this.projectUrl;
     }
 
     public void setProjectUrl (String projectUrl) {


### PR DESCRIPTION
Fixed url's not having the https: prefix
![](https://cdn.discordapp.com/attachments/258416579799154688/375132876599197697/Screenshot_20171101-040355.png)
