### PR TITLE
Add request auto-deletion

### DIFF
--- a/src/main/java/com/mcmoddev/bot/MMDBot.java
+++ b/src/main/java/com/mcmoddev/bot/MMDBot.java
@@ -3,9 +3,16 @@ package com.mcmoddev.bot;
 import com.google.gson.Gson;
 import com.jagrosh.jdautilities.command.CommandClient;
 import com.jagrosh.jdautilities.command.CommandClientBuilder;
-import com.mcmoddev.bot.commands.locked.info.*;
-import com.mcmoddev.bot.commands.unlocked.*;
-import com.mcmoddev.bot.commands.unlocked.search.*;
+import com.mcmoddev.bot.commands.locked.info.CmdGuild;
+import com.mcmoddev.bot.commands.locked.info.CmdRoles;
+import com.mcmoddev.bot.commands.locked.info.CmdUser;
+import com.mcmoddev.bot.commands.unlocked.CmdJustAsk;
+import com.mcmoddev.bot.commands.unlocked.CmdPaste;
+import com.mcmoddev.bot.commands.unlocked.CmdXy;
+import com.mcmoddev.bot.commands.unlocked.search.CmdBing;
+import com.mcmoddev.bot.commands.unlocked.search.CmdDuckDuckGo;
+import com.mcmoddev.bot.commands.unlocked.search.CmdGoogle;
+import com.mcmoddev.bot.commands.unlocked.search.CmdLmgtfy;
 import com.mcmoddev.bot.events.MiscEvents;
 import com.mcmoddev.bot.events.users.*;
 import com.mcmoddev.bot.misc.BotConfig;
@@ -15,16 +22,9 @@ import net.dv8tion.jda.api.entities.Activity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
-import java.nio.charset.StandardCharsets;
-
 import javax.security.auth.login.LoginException;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
 
 /**
  *
@@ -104,6 +104,7 @@ public final class MMDBot {
             botBuilder.addEventListeners(new EventNicknameChanged());
             botBuilder.addEventListeners(new EventRoleAdded());
             botBuilder.addEventListeners(new EventRoleRemoved());
+            botBuilder.addEventListeners(new EventReactionAdded());
             botBuilder.addEventListeners(new MiscEvents());
             botBuilder.setActivity(Activity.watching(config.getBotTextStatus()));
 

--- a/src/main/java/com/mcmoddev/bot/events/users/EventReactionAdded.java
+++ b/src/main/java/com/mcmoddev/bot/events/users/EventReactionAdded.java
@@ -44,7 +44,7 @@ public final class EventReactionAdded extends ListenerAdapter {
             final int goodReactions = Utils.getNumberOfMatchingReactions(message, Utils::isReactionGood);
             final int needsImprovementReactions = Utils.getNumberOfMatchingReactions(message, Utils::isReactionNeedsImprovement);
 
-            if ((badReactions + needsImprovementReactions * 0.5) - goodReactions > 10) {
+            if ((badReactions + needsImprovementReactions * 0.5) - goodReactions >= MMDBot.getConfig().getBadReactionThreshold()) {
                 channel.deleteMessageById(event.getMessageId()).reason(String.format(
                         "Bad request: %d bad reactions, %d needs improvement reactions, %d good reactions",
                         badReactions, needsImprovementReactions, goodReactions)

--- a/src/main/java/com/mcmoddev/bot/events/users/EventReactionAdded.java
+++ b/src/main/java/com/mcmoddev/bot/events/users/EventReactionAdded.java
@@ -33,6 +33,10 @@ public final class EventReactionAdded extends ListenerAdapter {
             final int needsImprovementReactions = Utils.getNumberOfMatchingReactions(message, Utils::isReactionNeedsImprovement);
 
             if ((badReactions + needsImprovementReactions * 0.5) - goodReactions >= MMDBot.getConfig().getBadReactionThreshold()) {
+                final TextChannel logChannel = guild.getTextChannelById(MMDBot.getConfig().getChannelIDDeletedMessages());
+                if (logChannel != null) {
+                    logChannel.sendMessage(String.format("Auto-deleted request from %s: %s", messageAuthor.getId(), message.getContentRaw())).queue();
+                }
                 channel.deleteMessageById(event.getMessageId()).reason(String.format(
                         "Bad request: %d bad reactions, %d needs improvement reactions, %d good reactions",
                         badReactions, needsImprovementReactions, goodReactions)

--- a/src/main/java/com/mcmoddev/bot/events/users/EventReactionAdded.java
+++ b/src/main/java/com/mcmoddev/bot/events/users/EventReactionAdded.java
@@ -2,7 +2,6 @@ package com.mcmoddev.bot.events.users;
 
 import com.mcmoddev.bot.MMDBot;
 import com.mcmoddev.bot.misc.Utils;
-import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
@@ -13,28 +12,17 @@ import net.dv8tion.jda.api.hooks.ListenerAdapter;
  */
 public final class EventReactionAdded extends ListenerAdapter {
 
-    private MessageHistory history = null;
-
     /**
      *
      */
     @Override
     public void onMessageReactionAdd(final MessageReactionAddEvent event) {
-        final User user = event.getUser();
-        final EmbedBuilder embed = new EmbedBuilder();
         final Guild guild = event.getGuild();
         final Long guildId = guild.getIdLong();
         final TextChannel channel = event.getTextChannel();
         final TextChannel discussionChannel = guild.getTextChannelById(MMDBot.getConfig().getChannelIDRequestsDiscussion());
 
-        if (history == null) {
-            history = channel.getHistory();
-            history.retrievePast(50).complete();
-            Utils.sleepTimer();
-        }
-        // This may cause memory issues if the bot is left on too long :/
-        history.retrieveFuture(25).complete();
-
+        MessageHistory history = MessageHistory.getHistoryAround(channel, event.getMessageId()).limit(1).complete();
         final Message message = history.getMessageById(event.getMessageId());
         if (message == null) return;
         final User messageAuthor = message.getAuthor();
@@ -59,7 +47,7 @@ public final class EventReactionAdded extends ListenerAdapter {
                         badReactions, needsImprovementReactions, goodReactions);
 
                 if (discussionChannel == null) return;
-                discussionChannel.sendMessage(responseBuilder.build()).complete();
+                discussionChannel.sendMessage(responseBuilder.build()).queue();
             }
         }
     }

--- a/src/main/java/com/mcmoddev/bot/events/users/EventReactionAdded.java
+++ b/src/main/java/com/mcmoddev/bot/events/users/EventReactionAdded.java
@@ -1,0 +1,58 @@
+package com.mcmoddev.bot.events.users;
+
+import com.mcmoddev.bot.MMDBot;
+import com.mcmoddev.bot.misc.Utils;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.MessageBuilder;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.TextChannel;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+
+/**
+ *
+ */
+public final class EventReactionAdded extends ListenerAdapter {
+
+    /**
+     *
+     */
+    @Override
+    public void onMessageReactionAdd(final MessageReactionAddEvent event) {
+        final User user = event.getUser();
+        final EmbedBuilder embed = new EmbedBuilder();
+        final Guild guild = event.getGuild();
+        final Long guildId = guild.getIdLong();
+        final TextChannel channel = event.getTextChannel();
+        final TextChannel discussionChannel = guild.getTextChannelById(MMDBot.getConfig().getChannelIDRequestsDiscussion());
+        final Message message = channel.getHistory().getMessageById(event.getMessageId());
+        if (message == null) return;
+        final User messageAuthor = message.getAuthor();
+
+        if (MMDBot.getConfig().getGuildID().equals(guildId) && MMDBot.getConfig().getChannelIDRequests().equals(channel.getIdLong())) {
+            final int badReactions = Utils.getNumberOfMatchingReactions(message, Utils::isReactionBad);
+            final int goodReactions = Utils.getNumberOfMatchingReactions(message, Utils::isReactionGood);
+            final int needsImprovementReactions = Utils.getNumberOfMatchingReactions(message, Utils::isReactionNeedsImprovement);
+
+            if ((badReactions + needsImprovementReactions * 0.5) - goodReactions > 10) {
+                channel.deleteMessageById(event.getMessageId()).reason(String.format(
+                        "Bad request: %d bad reactions, %d needs improvement reactions, %d good reactions",
+                        badReactions, needsImprovementReactions, goodReactions)
+                ).complete();
+
+                final MessageBuilder responseBuilder = new MessageBuilder();
+                responseBuilder.append(messageAuthor.getAsMention());
+                responseBuilder.append(", ");
+                responseBuilder.append("your request has been found to be low quality by community review and has been removed.\n" +
+                        "Please see other requests for how to do it correctly.");
+                responseBuilder.appendFormat("It received %d 'bad' reactions, %d 'needs improvement' reactions, and %d 'good' reactions",
+                        badReactions, needsImprovementReactions, goodReactions);
+
+                if (discussionChannel == null) return;
+                discussionChannel.sendMessage(responseBuilder.build());
+            }
+        }
+    }
+}

--- a/src/main/java/com/mcmoddev/bot/misc/BotConfig.java
+++ b/src/main/java/com/mcmoddev/bot/misc/BotConfig.java
@@ -131,6 +131,11 @@ public final class BotConfig {
     private Long[] emoteIDsGood = new Long[] { 0L };
 
     /**
+     *
+     */
+    private double badReactionThreshold;
+
+    /**
 	 *
 	 */
 	public BotConfig() {
@@ -337,4 +342,11 @@ public final class BotConfig {
         return emoteIDsGood;
     }
 
+    /**
+     *
+     * @return
+     */
+    public double getBadReactionThreshold() {
+        return badReactionThreshold;
+    }
 }

--- a/src/main/java/com/mcmoddev/bot/misc/BotConfig.java
+++ b/src/main/java/com/mcmoddev/bot/misc/BotConfig.java
@@ -61,6 +61,16 @@ public final class BotConfig {
     private Long channelIDConsole = 0L;
 
     /**
+     * ID for Requests Channel
+     */
+    private Long channelIDRequests = 0L;
+
+    /**
+     * ID for Requests Channel
+     */
+    private Long channelIDRequestsDiscussion = 0L;
+
+    /**
      *
      */
     private String roleStaff = "218607518048452610";
@@ -105,7 +115,22 @@ public final class BotConfig {
      */
     private String roleBooster = "590166091234279465";
 
-	/**
+    /**
+     *
+     */
+    private Long[] emoteIDsBad = new Long[] { 0L };
+
+    /**
+     *
+     */
+    private Long[] emoteIDsNeedsImprovement = new Long[] { 0L };
+
+    /**
+     *
+     */
+    private Long[] emoteIDsGood = new Long[] { 0L };
+
+    /**
 	 *
 	 */
 	public BotConfig() {
@@ -204,6 +229,22 @@ public final class BotConfig {
      *
      * @return
      */
+    public Long getChannelIDRequests() {
+        return channelIDRequests;
+    }
+
+    /**
+     *
+     * @return
+     */
+    public Long getChannelIDRequestsDiscussion() {
+        return channelIDRequestsDiscussion;
+    }
+
+    /**
+     *
+     * @return
+     */
     public String getRoleStaff() {
     	return roleStaff;
     }
@@ -271,4 +312,29 @@ public final class BotConfig {
     public String getRoleBooster() {
     	return roleBooster;
     }
+
+    /**
+     *
+     * @return
+     */
+    public Long[] getEmoteIDsBad() {
+        return emoteIDsBad;
+    }
+
+    /**
+     *
+     * @return
+     */
+    public Long[] getEmoteIDsNeedsImprovement() {
+        return emoteIDsNeedsImprovement;
+    }
+
+    /**
+     *
+     * @return
+     */
+    public Long[] getEmoteIDsGood() {
+        return emoteIDsGood;
+    }
+
 }

--- a/src/main/java/com/mcmoddev/bot/misc/Utils.java
+++ b/src/main/java/com/mcmoddev/bot/misc/Utils.java
@@ -1,13 +1,17 @@
 package com.mcmoddev.bot.misc;
 
+import com.mcmoddev.bot.MMDBot;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageReaction;
+
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
 import java.util.StringJoiner;
 import java.util.concurrent.TimeUnit;
-
-import com.mcmoddev.bot.MMDBot;
+import java.util.function.Predicate;
 
 /**
 *
@@ -82,5 +86,26 @@ public final class Utils {
      */
     public static String makeHyperlink(final String text, final String url) {
         return String.format("[%s](%s)", text, url);
+    }
+
+    public static int getNumberOfMatchingReactions(final Message message, final Predicate<Long> predicate) {
+        return message
+                .getReactions()
+                .stream()
+                .filter(messageReaction -> predicate.test(messageReaction.getReactionEmote().getIdLong()))
+                .mapToInt(MessageReaction::getCount)
+                .sum();
+    }
+
+    public static boolean isReactionGood(final Long emoteID) {
+        return Arrays.asList(MMDBot.getConfig().getEmoteIDsGood()).contains(emoteID);
+    }
+
+    public static boolean isReactionBad(final Long emoteID) {
+        return Arrays.asList(MMDBot.getConfig().getEmoteIDsBad()).contains(emoteID);
+    }
+
+    public static boolean isReactionNeedsImprovement(final Long emoteID) {
+        return Arrays.asList(MMDBot.getConfig().getEmoteIDsNeedsImprovement()).contains(emoteID);
     }
 }

--- a/src/main/java/com/mcmoddev/bot/misc/Utils.java
+++ b/src/main/java/com/mcmoddev/bot/misc/Utils.java
@@ -92,6 +92,7 @@ public final class Utils {
         return message
                 .getReactions()
                 .stream()
+                .filter(messageReaction -> messageReaction.getReactionEmote().isEmote())
                 .filter(messageReaction -> predicate.test(messageReaction.getReactionEmote().getIdLong()))
                 .mapToInt(MessageReaction::getCount)
                 .sum();


### PR DESCRIPTION
This PR allows the bot to remove requests that meet a certain 'badness threshold'. How 'bad' a request is is calculated with:
`(badReactions + needsImprovementReactions * 0.5) - goodReactions`

The PR adds six new config variables: the #requests and #requests-discussion channel IDs, the threshold for request deletion (would probably work well at 10) and arrays of emote IDs that are 'good', 'needs improvement', and 'bad':

 - :requestGood:, :loveIt:, :plus_one:, etc. would be 'good',
 - :requestneedsbetterformatting: and :requestneedsmoreinfo: would be 'needs improvement',
 - and :requestbad:, :minus_one:, etc. would be 'bad'.

When the bot auto-deletes a request, it copies the full text of the request to the deleted messages channel, and tells the requestor that their request was removed and why in #requests-discussion.