### PR TITLE
Add some new commands

### DIFF
--- a/src/main/java/com/mcmoddev/bot/MMDBot.java
+++ b/src/main/java/com/mcmoddev/bot/MMDBot.java
@@ -121,6 +121,7 @@ public final class MMDBot {
             commandBuilder.addCommand(new CmdDuckDuckGo());
             commandBuilder.addCommand(new CmdGoogle());
             commandBuilder.addCommand(new CmdLmgtfy());
+            commandBuilder.addCommand(new CmdEventsHelp());
             commandBuilder.setHelpWord("help");
 
             final CommandClient commandListener = commandBuilder.build();

--- a/src/main/java/com/mcmoddev/bot/MMDBot.java
+++ b/src/main/java/com/mcmoddev/bot/MMDBot.java
@@ -4,8 +4,8 @@ import com.google.gson.Gson;
 import com.jagrosh.jdautilities.command.CommandClient;
 import com.jagrosh.jdautilities.command.CommandClientBuilder;
 import com.mcmoddev.bot.commands.locked.info.CmdGuild;
+import com.mcmoddev.bot.commands.locked.info.CmdMe;
 import com.mcmoddev.bot.commands.locked.info.CmdRoles;
-import com.mcmoddev.bot.commands.locked.info.CmdUser;
 import com.mcmoddev.bot.commands.unlocked.*;
 import com.mcmoddev.bot.commands.unlocked.search.CmdBing;
 import com.mcmoddev.bot.commands.unlocked.search.CmdDuckDuckGo;
@@ -110,7 +110,7 @@ public final class MMDBot {
             commandBuilder.setOwnerId(MMDBot.getConfig().getOwnerID());
             commandBuilder.setPrefix(MMDBot.getConfig().getPrefix());
             commandBuilder.addCommand(new CmdGuild());
-            commandBuilder.addCommand(new CmdUser());
+            commandBuilder.addCommand(new CmdMe());
             commandBuilder.addCommand(new CmdRoles());
             commandBuilder.addCommand(new CmdJustAsk());
             commandBuilder.addCommand(new CmdPaste());

--- a/src/main/java/com/mcmoddev/bot/MMDBot.java
+++ b/src/main/java/com/mcmoddev/bot/MMDBot.java
@@ -3,9 +3,14 @@ package com.mcmoddev.bot;
 import com.google.gson.Gson;
 import com.jagrosh.jdautilities.command.CommandClient;
 import com.jagrosh.jdautilities.command.CommandClientBuilder;
-import com.mcmoddev.bot.commands.locked.info.*;
+import com.mcmoddev.bot.commands.locked.info.CmdGuild;
+import com.mcmoddev.bot.commands.locked.info.CmdRoles;
+import com.mcmoddev.bot.commands.locked.info.CmdUser;
 import com.mcmoddev.bot.commands.unlocked.*;
-import com.mcmoddev.bot.commands.unlocked.search.*;
+import com.mcmoddev.bot.commands.unlocked.search.CmdBing;
+import com.mcmoddev.bot.commands.unlocked.search.CmdDuckDuckGo;
+import com.mcmoddev.bot.commands.unlocked.search.CmdGoogle;
+import com.mcmoddev.bot.commands.unlocked.search.CmdLmgtfy;
 import com.mcmoddev.bot.events.MiscEvents;
 import com.mcmoddev.bot.events.users.*;
 import com.mcmoddev.bot.misc.BotConfig;
@@ -15,16 +20,9 @@ import net.dv8tion.jda.api.entities.Activity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
-import java.nio.charset.StandardCharsets;
-
 import javax.security.auth.login.LoginException;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
 
 /**
  *
@@ -117,6 +115,7 @@ public final class MMDBot {
             commandBuilder.addCommand(new CmdJustAsk());
             commandBuilder.addCommand(new CmdPaste());
             commandBuilder.addCommand(new CmdXy());
+            commandBuilder.addCommand(new CmdReadme());
             commandBuilder.addCommand(new CmdBing());
             commandBuilder.addCommand(new CmdDuckDuckGo());
             commandBuilder.addCommand(new CmdGoogle());

--- a/src/main/java/com/mcmoddev/bot/commands/locked/info/CmdMe.java
+++ b/src/main/java/com/mcmoddev/bot/commands/locked/info/CmdMe.java
@@ -1,0 +1,38 @@
+package com.mcmoddev.bot.commands.locked.info;
+
+import com.jagrosh.jdautilities.command.CommandEvent;
+import com.mcmoddev.bot.MMDBot;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.TextChannel;
+
+/**
+ *
+ */
+public final class CmdMe extends CmdUser {
+
+	/**
+	 *
+	 */
+    public CmdMe() {
+        super();
+        name = "me";
+        aliases = new String[]{"whoami", "myinfo"};
+        help = "Get information about your own user. **Locked to <#" + MMDBot.getConfig().getBotStuffChannelId() + ">**";
+    }
+
+    /**
+     *
+     */
+    @Override
+    protected void execute(final CommandEvent event) {
+        final TextChannel channel = event.getTextChannel();
+        final EmbedBuilder embed = createMemberEmbed(event.getMember());
+
+        final long channelID = MMDBot.getConfig().getBotStuffChannelId();
+        if (channel.getIdLong() != channelID) {
+            channel.sendMessage("This command is channel locked to <#" + channelID + ">").queue();
+        } else {
+            channel.sendMessage(embed.build()).queue();
+        }
+    }
+}

--- a/src/main/java/com/mcmoddev/bot/commands/unlocked/CmdEventsHelp.java
+++ b/src/main/java/com/mcmoddev/bot/commands/unlocked/CmdEventsHelp.java
@@ -1,0 +1,47 @@
+package com.mcmoddev.bot.commands.unlocked;
+
+import com.jagrosh.jdautilities.command.Command;
+import com.jagrosh.jdautilities.command.CommandEvent;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.TextChannel;
+
+import java.awt.*;
+import java.time.Instant;
+
+/**
+ *
+ */
+public final class CmdEventsHelp extends Command {
+
+	/**
+	 *
+	 */
+    private static final String IMAGE_URL =
+            "https://media.discordapp.net/attachments/179315645005955072/540214876929261590/why-doesnt-my-event-handler-work.gif";
+
+    /**
+     *
+     */
+    public CmdEventsHelp() {
+        super();
+        name = "eventshelp";
+        aliases = new String[]{"events", "why-doesnt-my-event-handler-work"};
+        help = "Gives info on how to use forge event handlers.";
+    }
+
+    /**
+     *
+     */
+    @Override
+    protected void execute(final CommandEvent event) {
+        final EmbedBuilder embed = new EmbedBuilder();
+        final TextChannel channel = event.getTextChannel();
+
+        embed.setTitle("Why doesn't my event handler work?");
+        embed.setImage(IMAGE_URL);
+        embed.setColor(Color.GREEN);
+        embed.setTimestamp(Instant.now());
+
+        channel.sendMessage(embed.build()).queue();
+    }
+}

--- a/src/main/java/com/mcmoddev/bot/commands/unlocked/CmdEventsHelp.java
+++ b/src/main/java/com/mcmoddev/bot/commands/unlocked/CmdEventsHelp.java
@@ -17,7 +17,7 @@ public final class CmdEventsHelp extends Command {
 	 *
 	 */
     private static final String IMAGE_URL =
-            "https://media.discordapp.net/attachments/179315645005955072/540214876929261590/why-doesnt-my-event-handler-work.gif";
+            "https://cdn.discordapp.com/attachments/665281306426474506/665605979798372392/eventhandler.png";
 
     /**
      *

--- a/src/main/java/com/mcmoddev/bot/commands/unlocked/CmdReadme.java
+++ b/src/main/java/com/mcmoddev/bot/commands/unlocked/CmdReadme.java
@@ -1,0 +1,50 @@
+package com.mcmoddev.bot.commands.unlocked;
+
+import com.jagrosh.jdautilities.command.Command;
+import com.jagrosh.jdautilities.command.CommandEvent;
+import com.mcmoddev.bot.MMDBot;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.TextChannel;
+
+import java.awt.*;
+import java.time.Instant;
+
+/**
+ *
+ */
+public final class CmdReadme extends Command {
+
+	/**
+	 *
+	 */
+    private static final String BODY =
+            "Please give <#" + MMDBot.getConfig().getChannelIDReadme() + "> a thorough read, **including** "
+                    + "the full text of the Code of Conduct, which is linked there. "
+                    + "Having everyone read and understand these rules and guidelines helps keep this server "
+                    + "functioning well as a space for collaboration and discussion. Thank you.";
+
+    /**
+     *
+     */
+    public CmdReadme() {
+        super();
+        name = "readme";
+        aliases = new String[] { "read-me" };
+        help = "Tells you to read the readme.";
+    }
+
+    /**
+     *
+     */
+    @Override
+    protected void execute(final CommandEvent event) {
+        final EmbedBuilder embed = new EmbedBuilder();
+        final TextChannel channel = event.getTextChannel();
+
+        embed.setTitle("Please read the readme.");
+        embed.setDescription(BODY);
+        embed.setColor(Color.RED);
+        embed.setTimestamp(Instant.now());
+        channel.sendMessage(embed.build()).queue();
+    }
+}

--- a/src/main/java/com/mcmoddev/bot/misc/BotConfig.java
+++ b/src/main/java/com/mcmoddev/bot/misc/BotConfig.java
@@ -51,6 +51,11 @@ public final class BotConfig {
     private Long channelIDDeletedMessages = 0L;
 
     /**
+     * ID for Readme Channel
+     */
+    private Long channelIDReadme = 0L;
+
+    /**
      * ID for Debug Channel.
      */
     private Long channelIDDebug = 0L;
@@ -200,6 +205,11 @@ public final class BotConfig {
         return channelIDConsole;
     }
 
+    /**
+     *
+     * @return
+     */
+    public Long getChannelIDReadme() { return channelIDReadme; }
     /**
      *
      * @return

--- a/src/main/java/com/mcmoddev/bot/misc/Utils.java
+++ b/src/main/java/com/mcmoddev/bot/misc/Utils.java
@@ -1,13 +1,15 @@
 package com.mcmoddev.bot.misc;
 
+import com.mcmoddev.bot.MMDBot;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.StringJoiner;
 import java.util.concurrent.TimeUnit;
-
-import com.mcmoddev.bot.MMDBot;
 
 /**
 *
@@ -82,5 +84,13 @@ public final class Utils {
      */
     public static String makeHyperlink(final String text, final String url) {
         return String.format("[%s](%s)", text, url);
+    }
+
+    public static Member getMemberFromString(final String memberString, final Guild guild) {
+        if (memberString.contains("#")) {
+            return guild.getMemberByTag(memberString);
+        } else {
+            return guild.getMemberById(memberString);
+        }
     }
 }


### PR DESCRIPTION
This PR adds three new commands:
 - The readme (alias: read-me) command, which can be used to tell someone to read the readme and CoC.
 - The eventshelp (aliases: events, why-doesnt-my-event-handler-work) command, which posts an image I've made that's an updated version of the "Why doesn't my event handler work?" image.
 - The user (aliases: whois, userinfo) command, like the me command, but can take either a user id or a name#discriminator tag.