### PR TITLE
Add sticky roles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ data/
 
 #BotStuff
 mmdbot_config.json
+mmdbot_sticky_roles.json
 #Just in case anyone else has this still.
 config.json 
 bot_logs/*

--- a/src/main/java/com/mcmoddev/bot/events/users/EventUserJoined.java
+++ b/src/main/java/com/mcmoddev/bot/events/users/EventUserJoined.java
@@ -1,15 +1,16 @@
 package com.mcmoddev.bot.events.users;
 
 import com.mcmoddev.bot.MMDBot;
+import com.mcmoddev.bot.misc.Utils;
 import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.entities.Guild;
-import net.dv8tion.jda.api.entities.TextChannel;
-import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberJoinEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 
-import java.awt.Color;
+import java.awt.*;
 import java.time.Instant;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  *
@@ -26,13 +27,17 @@ public final class EventUserJoined extends ListenerAdapter {
         final Guild guild = event.getGuild();
         final Long guildId = guild.getIdLong();
         final TextChannel channel = guild.getTextChannelById(MMDBot.getConfig().getChannelIDBasicEvents().toString());
+        final Member member = guild.getMember(user);
 
         if (MMDBot.getConfig().getGuildID().equals(guildId)) {
+            final List<Role> roles = Utils.getOldUserRoles(guild, user.getIdLong());
+            roles.forEach(role -> guild.addRoleToMember(member, role).queue());
             embed.setColor(Color.GREEN);
             embed.setTitle("User Joined");
             embed.setThumbnail(user.getEffectiveAvatarUrl());
             embed.addField("User:", user.getName() + " #" + user.getDiscriminator(), true);
             embed.addField("User ID:", user.getId(), true);
+            embed.addField("Roles:", roles.stream().map(IMentionable::getAsMention).collect(Collectors.joining()), true);
             embed.setTimestamp(Instant.now());
 
             channel.sendMessage(embed.build()).queue();

--- a/src/main/java/com/mcmoddev/bot/events/users/EventUserLeft.java
+++ b/src/main/java/com/mcmoddev/bot/events/users/EventUserLeft.java
@@ -1,15 +1,16 @@
 package com.mcmoddev.bot.events.users;
 
 import com.mcmoddev.bot.MMDBot;
+import com.mcmoddev.bot.misc.Utils;
 import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.entities.Guild;
-import net.dv8tion.jda.api.entities.TextChannel;
-import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberLeaveEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 
-import java.awt.Color;
+import java.awt.*;
 import java.time.Instant;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  *
@@ -26,14 +27,18 @@ public final class EventUserLeft extends ListenerAdapter {
         final Guild guild = event.getGuild();
         final Long guildId = guild.getIdLong();
         final TextChannel channel = guild.getTextChannelById(MMDBot.getConfig().getChannelIDBasicEvents());
+        final Member member = event.getMember();
+        final List<Role> roles;
+        roles = member.getRoles();
 
         if (MMDBot.getConfig().getGuildID().equals(guildId)) {
+            Utils.writeUserRoles(user.getIdLong(), roles);
             embed.setColor(Color.RED);
             embed.setTitle("User Left");
             embed.setThumbnail(user.getEffectiveAvatarUrl());
             embed.addField("User:", user.getName() + " #" + user.getDiscriminator(), true);
             embed.addField("User ID:", user.getId(), true);
-            //TODO Get the roles a user has on leaving the server and save them to a dat file of sorts or a DB.
+            embed.addField("Roles:", roles.stream().map(IMentionable::getAsMention).collect(Collectors.joining()), true);
             embed.setTimestamp(Instant.now());
 
             channel.sendMessage(embed.build()).queue();


### PR DESCRIPTION
Saves the roles a user has to mmdbot_sticky_roles.json, then loads them
back on join.

Looks like my IDE has changed the indents in Utils also.