### PR TITLE
Add a warning when the bot is close to deleting a request.

### DIFF
--- a/src/main/java/com/mcmoddev/bot/events/users/EventReactionAdded.java
+++ b/src/main/java/com/mcmoddev/bot/events/users/EventReactionAdded.java
@@ -52,6 +52,17 @@ public final class EventReactionAdded extends ListenerAdapter {
 
                 if (discussionChannel == null) return;
                 discussionChannel.sendMessage(responseBuilder.build()).queue();
+            } else if ((badReactions + needsImprovementReactions * 0.5) - goodReactions >= MMDBot.getConfig().getWarningBadReactionThreshold()) {
+                final MessageBuilder responseBuilder = new MessageBuilder();
+                responseBuilder.append(messageAuthor.getAsMention());
+                responseBuilder.append(", ");
+                responseBuilder.append("your request is close to being removed by community review.\n" +
+                        "Please edit your message to bring it to a higher standard.\n");
+                responseBuilder.appendFormat("It has so far received %d 'bad' reactions, %d 'needs improvement' reactions, and %d 'good' reactions.",
+                        badReactions, needsImprovementReactions, goodReactions);
+
+                if (discussionChannel == null) return;
+                discussionChannel.sendMessage(responseBuilder.build()).queue();
             }
         }
     }

--- a/src/main/java/com/mcmoddev/bot/misc/BotConfig.java
+++ b/src/main/java/com/mcmoddev/bot/misc/BotConfig.java
@@ -138,7 +138,12 @@ public final class BotConfig {
     /**
      *
      */
-    private double badReactionThreshold;
+    private double badReactionThreshold = 0.0;
+
+    /**
+     *
+     */
+    private double warningBadReactionThreshold = 0.0;
 
     /**
 	 *
@@ -361,5 +366,13 @@ public final class BotConfig {
      */
     public double getBadReactionThreshold() {
         return badReactionThreshold;
+    }
+
+    /**
+     *
+     * @return
+     */
+    public double getWarningBadReactionThreshold() {
+        return warningBadReactionThreshold;
     }
 }


### PR DESCRIPTION
This is untested, but the logic is the same as request deletion so I see no reason why it shouldn't work.
I'd probably set the `warningBadReactionThreshold` to around 4.