### PR TITLE
Add Toggle Server Pings command

### DIFF
--- a/src/main/java/com/mcmoddev/bot/MMDBot.java
+++ b/src/main/java/com/mcmoddev/bot/MMDBot.java
@@ -3,10 +3,10 @@ package com.mcmoddev.bot;
 import com.google.gson.Gson;
 import com.jagrosh.jdautilities.command.CommandClient;
 import com.jagrosh.jdautilities.command.CommandClientBuilder;
+import com.mcmoddev.bot.commands.locked.CmdToggleServerPings;
 import com.mcmoddev.bot.commands.locked.info.CmdGuild;
 import com.mcmoddev.bot.commands.locked.info.CmdMe;
 import com.mcmoddev.bot.commands.locked.info.CmdRoles;
-import com.mcmoddev.bot.commands.locked.info.CmdUser;
 import com.mcmoddev.bot.commands.unlocked.*;
 import com.mcmoddev.bot.commands.unlocked.search.CmdBing;
 import com.mcmoddev.bot.commands.unlocked.search.CmdDuckDuckGo;
@@ -123,6 +123,7 @@ public final class MMDBot {
             commandBuilder.addCommand(new CmdGoogle());
             commandBuilder.addCommand(new CmdLmgtfy());
             commandBuilder.addCommand(new CmdEventsHelp());
+            commandBuilder.addCommand(new CmdToggleServerPings());
             commandBuilder.setHelpWord("help");
 
             final CommandClient commandListener = commandBuilder.build();

--- a/src/main/java/com/mcmoddev/bot/MMDBot.java
+++ b/src/main/java/com/mcmoddev/bot/MMDBot.java
@@ -3,7 +3,7 @@ package com.mcmoddev.bot;
 import com.google.gson.Gson;
 import com.jagrosh.jdautilities.command.CommandClient;
 import com.jagrosh.jdautilities.command.CommandClientBuilder;
-import com.mcmoddev.bot.commands.locked.CmdToggleServerPings;
+import com.mcmoddev.bot.commands.locked.CmdToggleMcServerPings;
 import com.mcmoddev.bot.commands.locked.info.CmdGuild;
 import com.mcmoddev.bot.commands.locked.info.CmdMe;
 import com.mcmoddev.bot.commands.locked.info.CmdRoles;
@@ -123,7 +123,7 @@ public final class MMDBot {
             commandBuilder.addCommand(new CmdGoogle());
             commandBuilder.addCommand(new CmdLmgtfy());
             commandBuilder.addCommand(new CmdEventsHelp());
-            commandBuilder.addCommand(new CmdToggleServerPings());
+            commandBuilder.addCommand(new CmdToggleMcServerPings());
             commandBuilder.setHelpWord("help");
 
             final CommandClient commandListener = commandBuilder.build();

--- a/src/main/java/com/mcmoddev/bot/commands/locked/CmdToggleMcServerPings.java
+++ b/src/main/java/com/mcmoddev/bot/commands/locked/CmdToggleMcServerPings.java
@@ -13,15 +13,15 @@ import java.util.List;
 /**
  *
  */
-public class CmdToggleServerPings extends Command {
+public class CmdToggleMcServerPings extends Command {
 
 	/**
 	 *
 	 */
-	public CmdToggleServerPings() {
+	public CmdToggleMcServerPings() {
 		super();
-		name = "toggle-server-pings";
-		aliases = new String[]{"server-pings", "toggle-server-announcements", "server-announcements"};
+		name = "toggle-mc-server-pings";
+		aliases = new String[]{"mc-server-pings", "toggle-mc-server-announcements", "mc-server-announcements"};
 		help = "Give/remove from yourself the public server players role. **Locked to <#" + MMDBot.getConfig().getBotStuffChannelId() + ">**";
 	}
 

--- a/src/main/java/com/mcmoddev/bot/commands/locked/CmdToggleServerPings.java
+++ b/src/main/java/com/mcmoddev/bot/commands/locked/CmdToggleServerPings.java
@@ -1,0 +1,60 @@
+package com.mcmoddev.bot.commands.locked;
+
+import com.jagrosh.jdautilities.command.Command;
+import com.jagrosh.jdautilities.command.CommandEvent;
+import com.mcmoddev.bot.MMDBot;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.entities.TextChannel;
+
+import java.util.List;
+
+/**
+ *
+ */
+public class CmdToggleServerPings extends Command {
+
+	/**
+	 *
+	 */
+	public CmdToggleServerPings() {
+		super();
+		name = "toggle-server-pings";
+		aliases = new String[]{"server-pings", "toggle-server-announcements", "server-announcements"};
+		help = "Give/remove from yourself the public server players role. **Locked to <#" + MMDBot.getConfig().getBotStuffChannelId() + ">**";
+	}
+
+	/**
+	 *
+	 */
+	@Override
+	protected void execute(final CommandEvent event) {
+		final TextChannel channel = event.getTextChannel();
+		final Guild guild = event.getGuild();
+		final Member member = event.getMember();
+		final Role role = guild.getRoleById(MMDBot.getConfig().getRolePublicServerPlayer());
+
+		if (role == null) {
+			channel.sendMessage("The MMD Public Server Players role doesn't exist! The config is borked.").queue();
+			return;
+		}
+		final long channelID = MMDBot.getConfig().getBotStuffChannelId();
+		if (channel.getIdLong() != channelID) {
+			channel.sendMessage("This command is channel locked to <#" + channelID + ">").queue();
+			return;
+		}
+
+		final List<Role> roles = member.getRoles();
+		boolean added;
+		if (roles.contains(role)) {
+			guild.removeRoleFromMember(member, role).queue();
+			added = false;
+		} else {
+			guild.addRoleToMember(member, role).queue();
+			added = true;
+		}
+		channel.sendMessageFormat("%s, you %s have the MMD Public Server Players role.", member.getAsMention(), added ? "now" : "no longer").queue();
+	}
+
+}

--- a/src/main/java/com/mcmoddev/bot/misc/BotConfig.java
+++ b/src/main/java/com/mcmoddev/bot/misc/BotConfig.java
@@ -123,6 +123,11 @@ public final class BotConfig {
     /**
      *
      */
+    private String rolePublicServerPlayer = "325780906579066881";
+
+    /**
+     *
+     */
     private Long[] emoteIDsBad = new Long[] { 0L };
 
     /**
@@ -167,7 +172,7 @@ public final class BotConfig {
     public String getOwnerID() {
         return ownerID;
     }
-    
+
     /**
      *
      * @return
@@ -247,7 +252,7 @@ public final class BotConfig {
     public Long getChannelIDReadme() {
         return channelIDReadme;
     }
-  
+
     /**
      *
      * @return
@@ -334,6 +339,14 @@ public final class BotConfig {
      */
     public String getRoleBooster() {
     	return roleBooster;
+    }
+
+    /**
+     *
+     * @return
+     */
+    public String getRolePublicServerPlayer() {
+        return rolePublicServerPlayer;
     }
 
     /**


### PR DESCRIPTION
Gives/removes from the user the public server player role.
It's locked to #bot-stuff.

`toggle-server-pings` aliases: `server-pings`, `toggle-server-announcements`, `server-announcements`

Also adds `rolePublicServerPlayer` to config.