### PR TITLE
Update JDA to 4.2.0, JDA-utilities to 3.0.4, and GSON to 2.8.6.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,9 +22,9 @@ repositories {
 }
 
 dependencies {
-    compile 'com.jagrosh:jda-utilities:3.0.2'
-    compile 'net.dv8tion:JDA:4.0.0_59'
-    compile 'com.google.code.gson:gson:2.2.4'
+    compile 'com.jagrosh:jda-utilities:3.0.4'
+    compile 'net.dv8tion:JDA:4.2.0_168'
+    compile 'com.google.code.gson:gson:2.8.6'
     compile 'ch.qos.logback:logback-classic:1.2.3'
 }
 

--- a/src/main/java/com/mcmoddev/bot/MMDBot.java
+++ b/src/main/java/com/mcmoddev/bot/MMDBot.java
@@ -20,12 +20,15 @@ import com.mcmoddev.bot.misc.BotConfig;
 import net.dv8tion.jda.api.AccountType;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
+import net.dv8tion.jda.api.requests.GatewayIntent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.security.auth.login.LoginException;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  *
@@ -76,6 +79,17 @@ public final class MMDBot {
 	public static JDA getInstance() {
 		return INSTANCE;
 	}
+
+	private static Set<GatewayIntent> intents = new HashSet<>();
+	static {
+		intents.add(GatewayIntent.DIRECT_MESSAGES);
+		intents.add(GatewayIntent.GUILD_BANS);
+		intents.add(GatewayIntent.GUILD_EMOJIS);
+		intents.add(GatewayIntent.GUILD_MEMBERS);
+		intents.add(GatewayIntent.GUILD_MESSAGE_REACTIONS);
+		intents.add(GatewayIntent.GUILD_MESSAGES);
+		intents.add(GatewayIntent.GUILD_PRESENCES);
+	};
 
 	/**
 	 * @param args Arguments provided to the program.
@@ -137,6 +151,8 @@ public final class MMDBot {
 
 			final CommandClient commandListener = commandBuilder.build();
 			botBuilder.addEventListeners(commandListener);
+			botBuilder.enableIntents(intents);
+
 			INSTANCE = botBuilder.build();
 		} catch (final LoginException exception) {
 			LOGGER.error("Error logging in the bot! Please give the bot a valid token in the config file.", exception);

--- a/src/main/java/com/mcmoddev/bot/events/users/EventUserLeft.java
+++ b/src/main/java/com/mcmoddev/bot/events/users/EventUserLeft.java
@@ -4,7 +4,7 @@ import com.mcmoddev.bot.MMDBot;
 import com.mcmoddev.bot.misc.Utils;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.*;
-import net.dv8tion.jda.api.events.guild.member.GuildMemberLeaveEvent;
+import net.dv8tion.jda.api.events.guild.member.GuildMemberRemoveEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 
 import java.awt.*;
@@ -21,7 +21,7 @@ public final class EventUserLeft extends ListenerAdapter {
 	 *
 	 */
 	@Override
-	public void onGuildMemberLeave(final GuildMemberLeaveEvent event) {
+	public void onGuildMemberRemove(final GuildMemberRemoveEvent event) {
 		final User user = event.getUser();
 		final EmbedBuilder embed = new EmbedBuilder();
 		final Guild guild = event.getGuild();


### PR DESCRIPTION
JDA must be updated because of breaking discord API changes in November. I took the chance to update JDA-utilities and GSON too.

This PR also makes the bot declare `GatewayIntents`, future-proofing it.