### PR TITLE
Make bot only warn users for bad requests once.

### DIFF
--- a/src/main/java/com/mcmoddev/bot/events/users/EventReactionAdded.java
+++ b/src/main/java/com/mcmoddev/bot/events/users/EventReactionAdded.java
@@ -7,10 +7,15 @@ import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  *
  */
 public final class EventReactionAdded extends ListenerAdapter {
+
+	private Set<Message> warnedMessages = new HashSet<>();
 
 	/**
 	 *
@@ -50,9 +55,11 @@ public final class EventReactionAdded extends ListenerAdapter {
 				responseBuilder.appendFormat("It received %d 'bad' reactions, %d 'needs improvement' reactions, and %d 'good' reactions.",
 					badReactions, needsImprovementReactions, goodReactions);
 
+				warnedMessages.remove(message);
+
 				if (discussionChannel == null) return;
 				discussionChannel.sendMessage(responseBuilder.build()).queue();
-			} else if ((badReactions + needsImprovementReactions * 0.5) - goodReactions >= MMDBot.getConfig().getWarningBadReactionThreshold()) {
+			} else if (!warnedMessages.contains(message) && (badReactions + needsImprovementReactions * 0.5) - goodReactions >= MMDBot.getConfig().getWarningBadReactionThreshold()) {
 				final MessageBuilder responseBuilder = new MessageBuilder();
 				responseBuilder.append(messageAuthor.getAsMention());
 				responseBuilder.append(", ");
@@ -60,6 +67,8 @@ public final class EventReactionAdded extends ListenerAdapter {
 					"Please edit your message to bring it to a higher standard.\n");
 				responseBuilder.appendFormat("It has so far received %d 'bad' reactions, %d 'needs improvement' reactions, and %d 'good' reactions.",
 					badReactions, needsImprovementReactions, goodReactions);
+
+				warnedMessages.add(message);
 
 				if (discussionChannel == null) return;
 				discussionChannel.sendMessage(responseBuilder.build()).queue();

--- a/src/main/java/com/mcmoddev/bot/events/users/EventReactionAdded.java
+++ b/src/main/java/com/mcmoddev/bot/events/users/EventReactionAdded.java
@@ -57,8 +57,10 @@ public final class EventReactionAdded extends ListenerAdapter {
 
 				warnedMessages.remove(message);
 
-				if (discussionChannel == null) return;
-				discussionChannel.sendMessage(responseBuilder.build()).queue();
+				Message response = responseBuilder.build();
+				messageAuthor.openPrivateChannel().submit().thenCompose(c -> c.sendMessage(response).submit()).whenComplete((msg, throwable) -> {
+					if (throwable != null && discussionChannel != null) discussionChannel.sendMessage(response).queue();
+				});
 			} else if (!warnedMessages.contains(message) && (badReactions + needsImprovementReactions * 0.5) - goodReactions >= MMDBot.getConfig().getWarningBadReactionThreshold()) {
 				final MessageBuilder responseBuilder = new MessageBuilder();
 				responseBuilder.append(messageAuthor.getAsMention());
@@ -70,8 +72,10 @@ public final class EventReactionAdded extends ListenerAdapter {
 
 				warnedMessages.add(message);
 
-				if (discussionChannel == null) return;
-				discussionChannel.sendMessage(responseBuilder.build()).queue();
+				Message response = responseBuilder.build();
+				messageAuthor.openPrivateChannel().submit().thenCompose(c -> c.sendMessage(response).submit()).whenComplete((msg, throwable) -> {
+					if (throwable != null && discussionChannel != null) discussionChannel.sendMessage(response).queue();
+				});
 			}
 		}
 	}


### PR DESCRIPTION
(Perhaps the warning could be a DM?)

Also I'd recommend changing `warningBadReactionThreshold` in the config down a little.