### PR TITLE
Clean up roles command

### DIFF
--- a/src/main/java/com/mcmoddev/mmdbot/commands/info/server/CmdRoles.java
+++ b/src/main/java/com/mcmoddev/mmdbot/commands/info/server/CmdRoles.java
@@ -46,12 +46,12 @@ public final class CmdRoles extends Command {
 
         final String rolesCount = event.getGuild().getRoles()
 			.stream()
-			.filter(role -> !role.isManaged())
+			.filter(role -> !role.isManaged()) // Filter out managed roles
 			.map(role -> role.getAsMention() + ": " + role.getGuild().getMembersWithRoles(role).size())
 			.collect(Collectors.joining("\n"));
 
         embed.setColor(Color.GREEN);
-        embed.setTitle("Users With Role");
+        embed.setTitle("Users With Roles");
         embed.setDescription("A count of how many members have been assigned some of MMD's many roles.");
         embed.addField("Role count:", rolesCount, true);
         embed.setTimestamp(Instant.now());

--- a/src/main/java/com/mcmoddev/mmdbot/commands/info/server/CmdRoles.java
+++ b/src/main/java/com/mcmoddev/mmdbot/commands/info/server/CmdRoles.java
@@ -12,14 +12,15 @@ import java.awt.Color;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
- *
+ * A {@link Command} for listing the roles and their member counts.
  */
 public final class CmdRoles extends Command {
 
     /**
-     *
+     * Constructs this command, to be registered in a {@link com.jagrosh.jdautilities.command.CommandClient}.
      */
     public CmdRoles() {
         super();
@@ -29,18 +30,12 @@ public final class CmdRoles extends Command {
     }
 
     /**
-     * Get the amount of members per role.
-     *
-     * @param guild The guild we are in.
-     * @param id    The ID of the role.
-     * @return
-     */
-    private String getRoleMemberCount(final Guild guild, final String id) {
-        return Integer.toString(guild.getMembersWithRoles(guild.getRoleById(id)).size());
-    }
-
-    /**
-     *
+     * Executes the command.
+	 * <p>
+	 * Sends a message with a listing of all roles in the guild, along with a count of how many members hold those roles.
+	 * The message is sent in the same channel where the command was sent from.
+	 *
+	 * @param event The command event
      */
     @Override
     protected void execute(final CommandEvent event) {
@@ -49,20 +44,16 @@ public final class CmdRoles extends Command {
         final EmbedBuilder embed = new EmbedBuilder();
         final TextChannel channel = event.getTextChannel();
 
-        for (Role roles : event.getGuild().getRoles()) {
-            try {
-                if (!roleList.containsKey(roles.getName())) {
-                    roleList.put(roles.getName(), getRoleMemberCount(guild, roles.getId()));
-                }
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-        }
+        final String rolesCount = event.getGuild().getRoles()
+			.stream()
+			.filter(role -> !role.isManaged())
+			.map(role -> role.getAsMention() + ": " + role.getGuild().getMembersWithRoles(role).size())
+			.collect(Collectors.joining("\n"));
 
         embed.setColor(Color.GREEN);
         embed.setTitle("Users With Role");
         embed.setDescription("A count of how many members have been assigned some of MMD's many roles.");
-        embed.addField("Role count:", Utils.mapToString(Utils.sortByValue(roleList, true)), true);
+        embed.addField("Role count:", rolesCount, true);
         embed.setTimestamp(Instant.now());
         channel.sendMessage(embed.build()).queue();
     }


### PR DESCRIPTION
Hello! This PR cleans up the `CmdRole` class. 
* It adds in more javadocs, so checkstyle is happier and it more accurately describes the behavior of the class.
* It refactors the code for listing the roles to use a stream instead of looping over the roles list using an enhanced-`for`.
  * This makes the class slimmer, removing the other private function in the class (since it serves no purpose).
  * The stream can be filtered to exclude certain roles from the counts; in this PR, all managed roles (roles which are added by bots and cannot be assigned to other users/bots) are excluded from the count.
  * The stream can also be sorted if required; currently, the stream does no sorting so it _should_ retain the default order (the order of the Discord roles hierarchy, as seen in the Roles page in the Server Settings).
* The roles count is also changed to use mentions, so roles can be more visually distinct.
* The grammar of the embed title is fixed, from `Users with Role` to `Users with Roles`.

<details>
<summary>Image of the command output due to this PR</summary>
<img src="https://user-images.githubusercontent.com/21304337/103449787-04b49800-4ce8-11eb-954e-dccbaa85a0d9.png"/>
</details>
