### PR TITLE
Move from JSON-based configs to TOML-based configs using NightConfig

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,11 +23,14 @@ repositories {
 }
 
 dependencies {
-    compile "com.jagrosh:jda-utilities:${project.jdautils_version}"
-    compile "net.dv8tion:JDA:${project.jda_version}"
+    implementation "com.jagrosh:jda-utilities:${project.jdautils_version}"
+    implementation "net.dv8tion:JDA:${project.jda_version}"
     implementation "com.google.guava:guava:${project.guava_version}"
-    compile "com.google.code.gson:gson:${project.gson_version}"
-    compile "ch.qos.logback:logback-classic:${project.logback_classic_version}"
+    implementation "com.google.code.gson:gson:${project.gson_version}"
+    implementation "ch.qos.logback:logback-classic:${project.logback_classic_version}"
+    implementation "com.electronwill.night-config:toml:${project.nightconfig_version}"
+
+    testImplementation "org.junit.jupiter:junit-jupiter:5.6.0"
 }
 
 jar {
@@ -62,10 +65,6 @@ idea.module {
 
 javadoc {
   failOnError = false
-}
-
-dependencies {
-    testImplementation('org.junit.jupiter:junit-jupiter:5.6.0')
 }
 
 test {
@@ -133,6 +132,6 @@ pmd {
     'java-unnecessary',
     'java-unusedcode'
   ]
-  toolVersion = '5.8.1'; // 6.19.0
+  toolVersion = '5.8.1' // 6.19.0
 //  incrementalAnalysis = true // Requires PMD 6.0.0 or newer
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,3 +4,4 @@ jda_version=4.2.0_168
 guava_version=29.0-jre
 gson_version=2.8.6
 logback_classic_version=1.2.3
+nightconfig_version=3.6.3

--- a/src/main/java/com/mcmoddev/mmdbot/commands/fun/CmdCatFacts.java
+++ b/src/main/java/com/mcmoddev/mmdbot/commands/fun/CmdCatFacts.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonParser;
 import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.mcmoddev.mmdbot.MMDBot;
+import com.mcmoddev.mmdbot.core.Utils;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -40,6 +41,7 @@ public class CmdCatFacts extends Command {
 
     @Override
     protected void execute(CommandEvent event) {
+		if (!Utils.checkCommand(this, event)) return;
         if (getFact() != null) {
             event.getChannel().sendMessage(getFact()).queue();
         }

--- a/src/main/java/com/mcmoddev/mmdbot/commands/fun/CmdToggleEventPings.java
+++ b/src/main/java/com/mcmoddev/mmdbot/commands/fun/CmdToggleEventPings.java
@@ -3,6 +3,7 @@ package com.mcmoddev.mmdbot.commands.fun;
 import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.mcmoddev.mmdbot.MMDBot;
+import com.mcmoddev.mmdbot.core.Utils;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
@@ -26,10 +27,11 @@ public class CmdToggleEventPings extends Command {
     }
 
     protected void execute(final CommandEvent event) {
+		if (!Utils.checkCommand(this, event)) return;
         final TextChannel channel = event.getTextChannel();
         final Guild guild = event.getGuild();
         final Member member = event.getMember();
-        final Role role = guild.getRoleById(MMDBot.getConfig().getRoleEventNotifications());
+        final Role role = guild.getRoleById(MMDBot.getConfig().getRole("pings.event-pings"));
 
         if (role == null) {
             channel.sendMessage("The Event Notifications role doesn't exist! The config must be borked.").queue();

--- a/src/main/java/com/mcmoddev/mmdbot/commands/fun/CmdToggleMcServerPings.java
+++ b/src/main/java/com/mcmoddev/mmdbot/commands/fun/CmdToggleMcServerPings.java
@@ -3,6 +3,7 @@ package com.mcmoddev.mmdbot.commands.fun;
 import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.mcmoddev.mmdbot.MMDBot;
+import com.mcmoddev.mmdbot.core.Utils;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
@@ -30,10 +31,11 @@ public class CmdToggleMcServerPings extends Command {
      */
     @Override
     protected void execute(final CommandEvent event) {
+		if (!Utils.checkCommand(this, event)) return;
         final TextChannel channel = event.getTextChannel();
         final Guild guild = event.getGuild();
         final Member member = event.getMember();
-        final Role role = guild.getRoleById(MMDBot.getConfig().getRolePublicServerPlayer());
+        final Role role = guild.getRoleById(MMDBot.getConfig().getRole("pings.toggle-mc-server-pings"));
 
         if (role == null) {
             channel.sendMessage("The MMD Public Server Players role doesn't exist! The config is borked.").queue();

--- a/src/main/java/com/mcmoddev/mmdbot/commands/info/CmdBuild.java
+++ b/src/main/java/com/mcmoddev/mmdbot/commands/info/CmdBuild.java
@@ -3,6 +3,7 @@ package com.mcmoddev.mmdbot.commands.info;
 import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.mcmoddev.mmdbot.MMDBot;
+import com.mcmoddev.mmdbot.core.Utils;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.TextChannel;
@@ -30,6 +31,7 @@ public final class CmdBuild extends Command {
      */
     @Override
     protected void execute(final CommandEvent event) {
+		if (!Utils.checkCommand(this, event)) return;
         final Guild guild = event.getGuild();
         final EmbedBuilder embed = new EmbedBuilder();
         final TextChannel channel = event.getTextChannel();

--- a/src/main/java/com/mcmoddev/mmdbot/commands/info/CmdEventsHelp.java
+++ b/src/main/java/com/mcmoddev/mmdbot/commands/info/CmdEventsHelp.java
@@ -2,6 +2,7 @@ package com.mcmoddev.mmdbot.commands.info;
 
 import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.mcmoddev.mmdbot.core.Utils;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.TextChannel;
 
@@ -34,6 +35,7 @@ public final class CmdEventsHelp extends Command {
      */
     @Override
     protected void execute(final CommandEvent event) {
+		if (!Utils.checkCommand(this, event)) return;
         final EmbedBuilder embed = new EmbedBuilder();
         final TextChannel channel = event.getTextChannel();
 

--- a/src/main/java/com/mcmoddev/mmdbot/commands/info/CmdFabricVersion.java
+++ b/src/main/java/com/mcmoddev/mmdbot/commands/info/CmdFabricVersion.java
@@ -2,6 +2,7 @@ package com.mcmoddev.mmdbot.commands.info;
 
 import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.mcmoddev.mmdbot.core.Utils;
 import com.mcmoddev.mmdbot.updatenotifiers.fabric.FabricVersionHelper;
 import com.mcmoddev.mmdbot.updatenotifiers.game.MinecraftVersionHelper;
 import net.dv8tion.jda.api.EmbedBuilder;
@@ -30,6 +31,7 @@ public final class CmdFabricVersion extends Command {
      */
     @Override
     protected void execute(final CommandEvent event) {
+		if (!Utils.checkCommand(this, event)) return;
         final EmbedBuilder embed = new EmbedBuilder();
         final TextChannel channel = event.getTextChannel();
 

--- a/src/main/java/com/mcmoddev/mmdbot/commands/info/CmdForgeVersion.java
+++ b/src/main/java/com/mcmoddev/mmdbot/commands/info/CmdForgeVersion.java
@@ -31,10 +31,11 @@ public final class CmdForgeVersion extends Command {
 	 */
 	@Override
 	protected void execute(final CommandEvent event) {
+		if (!Utils.checkCommand(this, event)) return;
 		final EmbedBuilder embed = new EmbedBuilder();
 		final TextChannel channel = event.getTextChannel();
 
-		MinecraftForgeVersion latest = null;
+		MinecraftForgeVersion latest;
 		try {
 			latest = ForgeVersionHelper.getLatestMcVersionForgeVersions();
 		} catch (Exception e) {

--- a/src/main/java/com/mcmoddev/mmdbot/commands/info/CmdJustAsk.java
+++ b/src/main/java/com/mcmoddev/mmdbot/commands/info/CmdJustAsk.java
@@ -38,6 +38,7 @@ public final class CmdJustAsk extends Command {
      */
     @Override
     protected void execute(final CommandEvent event) {
+		if (!Utils.checkCommand(this, event)) return;
         final EmbedBuilder embed = new EmbedBuilder();
         final TextChannel channel = event.getTextChannel();
 

--- a/src/main/java/com/mcmoddev/mmdbot/commands/info/CmdMinecraftVersion.java
+++ b/src/main/java/com/mcmoddev/mmdbot/commands/info/CmdMinecraftVersion.java
@@ -2,6 +2,7 @@ package com.mcmoddev.mmdbot.commands.info;
 
 import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.mcmoddev.mmdbot.core.Utils;
 import com.mcmoddev.mmdbot.updatenotifiers.game.MinecraftVersionHelper;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.TextChannel;
@@ -29,6 +30,7 @@ public final class CmdMinecraftVersion extends Command {
      */
     @Override
     protected void execute(final CommandEvent event) {
+		if (!Utils.checkCommand(this, event)) return;
         final EmbedBuilder embed = new EmbedBuilder();
         final TextChannel channel = event.getTextChannel();
 

--- a/src/main/java/com/mcmoddev/mmdbot/commands/info/CmdPaste.java
+++ b/src/main/java/com/mcmoddev/mmdbot/commands/info/CmdPaste.java
@@ -44,6 +44,7 @@ public final class CmdPaste extends Command {
      */
     @Override
     protected void execute(final CommandEvent event) {
+		if (!Utils.checkCommand(this, event)) return;
         final EmbedBuilder embed = new EmbedBuilder();
         final TextChannel channel = event.getTextChannel();
 

--- a/src/main/java/com/mcmoddev/mmdbot/commands/info/CmdSearch.java
+++ b/src/main/java/com/mcmoddev/mmdbot/commands/info/CmdSearch.java
@@ -3,6 +3,7 @@ package com.mcmoddev.mmdbot.commands.info;
 import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.mcmoddev.mmdbot.MMDBot;
+import com.mcmoddev.mmdbot.core.Utils;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -35,6 +36,7 @@ public class CmdSearch extends Command {
      * @param event The {@link CommandEvent CommandEvent} that triggered this Command.
      */
     protected void execute(final CommandEvent event) {
+		if (!Utils.checkCommand(this, event)) return;
         if (event.getArgs().isEmpty()) {
             event.getChannel().sendMessage("No arguments given!").queue();
             return;

--- a/src/main/java/com/mcmoddev/mmdbot/commands/info/CmdXy.java
+++ b/src/main/java/com/mcmoddev/mmdbot/commands/info/CmdXy.java
@@ -38,6 +38,7 @@ public final class CmdXy extends Command {
      */
     @Override
     protected void execute(final CommandEvent event) {
+		if (!Utils.checkCommand(this, event)) return;
         final EmbedBuilder embed = new EmbedBuilder();
         final TextChannel channel = event.getTextChannel();
 

--- a/src/main/java/com/mcmoddev/mmdbot/commands/info/server/CmdGuild.java
+++ b/src/main/java/com/mcmoddev/mmdbot/commands/info/server/CmdGuild.java
@@ -2,7 +2,6 @@ package com.mcmoddev.mmdbot.commands.info.server;
 
 import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
-import com.mcmoddev.mmdbot.MMDBot;
 import com.mcmoddev.mmdbot.core.Utils;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Guild;
@@ -34,6 +33,7 @@ public final class CmdGuild extends Command {
      */
     @Override
     protected void execute(final CommandEvent event) {
+    	if (!Utils.checkCommand(this, event)) return;
         final Guild guild = event.getGuild();
         final EmbedBuilder embed = new EmbedBuilder();
         final TextChannel channel = event.getTextChannel();
@@ -51,12 +51,6 @@ public final class CmdGuild extends Command {
         embed.addField("Date created:", new SimpleDateFormat("yyyy/MM/dd HH:mm", Locale.ENGLISH).format(dateGuildCreated.toEpochMilli()), true);
         embed.addField("Guilds age:", Utils.getTimeDifference(Utils.getLocalTime(dateGuildCreated), LocalDateTime.now()), true);
         embed.setTimestamp(Instant.now());
-
-        final long channelID = MMDBot.getConfig().getBotStuffChannelId();
-        if (channel.getIdLong() != channelID) {
-            channel.sendMessage("This command is channel locked to <#" + channelID + ">").queue();
-        } else {
-            channel.sendMessage(embed.build()).queue();
-        }
+		channel.sendMessage(embed.build()).queue();
     }
 }

--- a/src/main/java/com/mcmoddev/mmdbot/commands/info/server/CmdMe.java
+++ b/src/main/java/com/mcmoddev/mmdbot/commands/info/server/CmdMe.java
@@ -2,6 +2,7 @@ package com.mcmoddev.mmdbot.commands.info.server;
 
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.mcmoddev.mmdbot.commands.staff.CmdUser;
+import com.mcmoddev.mmdbot.core.Utils;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.TextChannel;
 
@@ -25,6 +26,7 @@ public final class CmdMe extends CmdUser {
      */
     @Override
     protected void execute(final CommandEvent event) {
+		if (!Utils.checkCommand(this, event)) return;
         final TextChannel channel = event.getTextChannel();
         final EmbedBuilder embed = createMemberEmbed(event.getMember());
         channel.sendMessage(embed.build()).queue();

--- a/src/main/java/com/mcmoddev/mmdbot/commands/info/server/CmdReadme.java
+++ b/src/main/java/com/mcmoddev/mmdbot/commands/info/server/CmdReadme.java
@@ -3,6 +3,7 @@ package com.mcmoddev.mmdbot.commands.info.server;
 import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.mcmoddev.mmdbot.MMDBot;
+import com.mcmoddev.mmdbot.core.Utils;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.TextChannel;
 
@@ -18,8 +19,9 @@ public final class CmdReadme extends Command {
      *
      */
     private static final String BODY =
-            "Please give <#" + MMDBot.getConfig().getChannelIDReadme() + "> a thorough read, this channel gives users a "
-                    + "guide to the server, how to get roles and general settling in notes. Thank you.";
+            "Please give <#" + MMDBot.getConfig().getChannel("info.readme") + "> a thorough read, this "
+                    + "channel gives users a guide to the server, how to get roles and general settling in notes. "
+                    + "Thank you.";
 
     /**
      *
@@ -36,6 +38,7 @@ public final class CmdReadme extends Command {
      */
     @Override
     protected void execute(final CommandEvent event) {
+		if (!Utils.checkCommand(this, event)) return;
         final EmbedBuilder embed = new EmbedBuilder();
         final TextChannel channel = event.getTextChannel();
 

--- a/src/main/java/com/mcmoddev/mmdbot/commands/info/server/CmdRoles.java
+++ b/src/main/java/com/mcmoddev/mmdbot/commands/info/server/CmdRoles.java
@@ -4,14 +4,10 @@ import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.mcmoddev.mmdbot.core.Utils;
 import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.entities.Guild;
-import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.TextChannel;
 
 import java.awt.Color;
 import java.time.Instant;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -39,8 +35,7 @@ public final class CmdRoles extends Command {
      */
     @Override
     protected void execute(final CommandEvent event) {
-        final Guild guild = event.getGuild();
-        final Map<String, String> roleList = new HashMap<>();
+		if (!Utils.checkCommand(this, event)) return;
         final EmbedBuilder embed = new EmbedBuilder();
         final TextChannel channel = event.getTextChannel();
 

--- a/src/main/java/com/mcmoddev/mmdbot/commands/info/server/CmdRules.java
+++ b/src/main/java/com/mcmoddev/mmdbot/commands/info/server/CmdRules.java
@@ -3,6 +3,7 @@ package com.mcmoddev.mmdbot.commands.info.server;
 import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
 import com.mcmoddev.mmdbot.MMDBot;
+import com.mcmoddev.mmdbot.core.Utils;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.TextChannel;
 
@@ -18,8 +19,8 @@ public class CmdRules extends Command {
      *
      */
     private static final String BODY =
-            "Please give <#" + MMDBot.getConfig().getChannelIDRules() + "> a thorough read, **including** "
-                    + "the full text of the Code of Conduct, which is linked there. "
+            "Please give <#" + MMDBot.getConfig().getChannel("info.rules") + "> a thorough read, "
+                    + "**including** the full text of the Code of Conduct, which is linked there. "
                     + "Having everyone read and understand these rules and guidelines helps keep this server "
                     + "functioning well as a space for collaboration and discussion. Thank you.";
 
@@ -37,6 +38,7 @@ public class CmdRules extends Command {
      */
     @Override
     protected void execute(final CommandEvent event) {
+		if (!Utils.checkCommand(this, event)) return;
         final EmbedBuilder embed = new EmbedBuilder();
         final TextChannel channel = event.getTextChannel();
 

--- a/src/main/java/com/mcmoddev/mmdbot/commands/staff/CmdMute.java
+++ b/src/main/java/com/mcmoddev/mmdbot/commands/staff/CmdMute.java
@@ -24,13 +24,15 @@ public class CmdMute extends Command {
 
     @Override
     protected void execute(CommandEvent event) {
+		if (!Utils.checkCommand(this, event)) return;
         final Guild guild = event.getGuild();
         final MessageChannel channel = event.getChannel();
         final String[] args = event.getArgs().split(" ");
         final Member author = event.getGuild().getMember(event.getAuthor());
+		if (author == null) return;
         final Member member = Utils.getMemberFromString(args[0], event.getGuild());
-        final Role mutedRole = guild.getRoleById(MMDBot.getConfig().getRoleMuted());
-        final TextChannel consoleChannel = guild.getTextChannelById(MMDBot.getConfig().getChannelIDConsole());
+        final Role mutedRole = guild.getRoleById(MMDBot.getConfig().getRole("muted"));
+        final TextChannel consoleChannel = guild.getTextChannelById(MMDBot.getConfig().getChannel("console"));
 
         if (author.hasPermission(Permission.KICK_MEMBERS)) {
             if (member == null) {
@@ -83,7 +85,9 @@ public class CmdMute extends Command {
             }
 
             channel.sendMessageFormat("Muted user %s for%s.", member.getAsMention(), timeString).queue();
-            consoleChannel.sendMessageFormat("Muted user %s for%s", member.getAsMention(), timeString).queue();
+            if (consoleChannel != null) {
+				consoleChannel.sendMessageFormat("Muted user %s for%s", member.getAsMention(), timeString).queue();
+			}
         } else {
             channel.sendMessage("You do not have permission to use this command.").queue();
         }

--- a/src/main/java/com/mcmoddev/mmdbot/commands/staff/CmdUnmute.java
+++ b/src/main/java/com/mcmoddev/mmdbot/commands/staff/CmdUnmute.java
@@ -22,13 +22,15 @@ public class CmdUnmute extends Command {
 
     @Override
     protected void execute(CommandEvent event) {
+		if (!Utils.checkCommand(this, event)) return;
         final Guild guild = event.getGuild();
         final MessageChannel channel = event.getChannel();
         final String[] args = event.getArgs().split(" ");
         final Member author = event.getGuild().getMember(event.getAuthor());
+        if (author == null) return;
         final Member member = Utils.getMemberFromString(args[0], event.getGuild());
-        final Role mutedRole = guild.getRoleById(MMDBot.getConfig().getRoleMuted());
-        final TextChannel consoleChannel = guild.getTextChannelById(MMDBot.getConfig().getChannelIDConsole());
+        final Role mutedRole = guild.getRoleById(MMDBot.getConfig().getRole("muted"));
+        final TextChannel consoleChannel = guild.getTextChannelById(MMDBot.getConfig().getChannel("console"));
 
         if (author.hasPermission(Permission.KICK_MEMBERS)) {
             if (member == null) {
@@ -43,7 +45,9 @@ public class CmdUnmute extends Command {
 
             guild.removeRoleFromMember(member, mutedRole).queue();
             channel.sendMessageFormat("Unmuted user %s.", member.getAsMention()).queue();
-            consoleChannel.sendMessageFormat("Unuted user %s.", member.getAsMention()).queue();
+            if (consoleChannel != null) {
+				consoleChannel.sendMessageFormat("Unmuted user %s.", member.getAsMention()).queue();
+			}
         } else {
             channel.sendMessage("You do not have permission to use this command.").queue();
         }

--- a/src/main/java/com/mcmoddev/mmdbot/commands/staff/CmdUser.java
+++ b/src/main/java/com/mcmoddev/mmdbot/commands/staff/CmdUser.java
@@ -35,6 +35,7 @@ public class CmdUser extends Command {
      */
     @Override
     protected void execute(final CommandEvent event) {
+		if (!Utils.checkCommand(this, event)) return;
         final TextChannel channel = event.getTextChannel();
         final Member member = Utils.getMemberFromString(event.getArgs(), event.getGuild());
         final EmbedBuilder embed = createMemberEmbed(member);

--- a/src/main/java/com/mcmoddev/mmdbot/core/BotConfig.java
+++ b/src/main/java/com/mcmoddev/mmdbot/core/BotConfig.java
@@ -1,400 +1,261 @@
 package com.mcmoddev.mmdbot.core;
 
+import com.electronwill.nightconfig.core.CommentedConfig;
+import com.electronwill.nightconfig.core.ConfigFormat;
+import com.electronwill.nightconfig.core.UnmodifiableConfig;
+import com.electronwill.nightconfig.core.file.CommentedFileConfig;
+import com.electronwill.nightconfig.core.file.FileNotFoundAction;
+import com.electronwill.nightconfig.toml.TomlFormat;
+import com.google.common.io.Resources;
+import com.jagrosh.jdautilities.commons.utils.SafeIdUtil;
+
+import javax.annotation.Nullable;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 /**
- *
+ * The configuration holder for the bot.
  */
-@Deprecated
 public final class BotConfig {
-
-    /**
-     * Discord Bot Token.
-     */
-    private String botToken = "Enter your bot token here.";
-
-    /**
-     * The ID of the bots owner. (Currently Proxy)
-     */
-    private String ownerID = "141990014346199040";
-
-    /**
-     * The bots Command Prefix.
-     */
-    private String prefix = "!mmd-";
-
-    /**
-     * The alternative command prefix, shorter and faster to type out than the long one.
-     */
-    private String alternativePrefix = "!";
-
-    /**
-     * The ID of the guild we will be running the bot in.
-     */
-    private Long guildID = 0L;
-
-    /**
-     * The channel the bots commands are primarily used in.
-     */
-    private Long botStuffChannelId = 0L;
-
-    //Channel ID's
-    /**
-     * ID for Basic Events Channel.
-     */
-    private Long channelIDBasicEvents = 0L;
-
-    /**
-     * ID for Important Events Channel.
-     */
-    private Long channelIDImportantEvents = 0L;
-
-    /**
-     * ID for Deleted Messages Channel.
-     */
-    private Long channelIDDeletedMessages = 0L;
-
-    /**
-     * ID for the Readme Channel.
-     */
-    private Long channelIDReadme = 0L;
-
-    /**
-     * ID for the Rules channel.
-     */
-    private Long channelIDRules = 0L;
-
-    /**
-     * ID for the bots Debug Channel.
-     */
-    private Long channelIDDebug = 0L;
-
-    /**
-     * ID for the bots Console Channel.
-     */
-    private Long channelIDConsole = 0L;
-
-    /**
-     * ID for Requests Channel
-     */
-    private Long channelIDRequests = 0L;
-
-    /**
-     * ID for Requests Channel
-     */
-    private Long channelIDRequestsDiscussion = 0L;
-
-    /**
-     * The channel ID of the channel we want to put forge updates notifications in.
-     */
-    private Long channelIDForgeNotifier = 0L;
-
-    /**
-     * The Staff role ID.
-     */
-    private String roleStaff = "218607518048452610";
-
-    /**
-     * The Community Reps role ID.
-     */
-    private String roleCommunityRep = "286223615765118986";
-
-    /**
-     * The Modder role ID.
-     */
-    private String roleModder = "191145754583105536";
-
-    /**
-     * The Artist role ID.
-     */
-    private String roleArtist = "179305517343047680";
-
-    /**
-     * The Streamer role ID.
-     */
-    private String roleStreamer = "219679192462131210";
-
-    /**
-     * The Modpack Maker role ID.
-     */
-    private String roleModpackMaker = "215403201090813952";
-
-    /**
-     * The Translator role ID.
-     */
-    private String roleTranslator = "201471697482678273";
-
-    /**
-     * The Event Notifications role ID.
-     */
-    private String roleEventNotifications = "777633879938826252";
-
-    /**
-     * The Booster role ID.
-     */
-    private String roleBooster = "590166091234279465";
-
-    /**
-     * The Public Server Player role ID.
-     */
-    private String rolePublicServerPlayer = "325780906579066881";
-
-    /**
-     * The Muted role ID.
-     */
-    private String roleMuted = "305875306529554432";
-
-    /**
-     * The ID of the request is bad emoticon.
-     */
-    private Long[] emoteIDsBad = new Long[]{0L};
-
-    /**
-     * The ID of the request needs improvement emoticon.
-     */
-    private Long[] emoteIDsNeedsImprovement = new Long[]{0L};
-
-    /**
-     * The ID of the request is good emoticon.
-     */
-    private Long[] emoteIDsGood = new Long[]{0L};
-
-    /**
-     * The bad reaction threshold.
-     */
-    private double badReactionThreshold = 0.0;
-
-    /**
-     * The bad reaction warning threshold.
-     */
-    private double warningBadReactionThreshold = 0.0;
-
-    /**
-     *
-     */
-    public BotConfig() {
-        //
-    }
-
-    /**
-     * @return The bots token.
-     */
-    public String getBotToken() {
-        return botToken;
-    }
-
-    /**
-     * @return The ID of the bot owner.
-     */
-    public String getOwnerID() {
-        return ownerID;
-    }
-
-    /**
-     * @return The prefix the bot will use when users run commands.
-     */
-    public String getPrefix() {
-        return prefix;
-    }
-
-    /**
-     * @return The alternative prefix the bot will use when users run commands.
-     */
-    public String getAlternativePrefix() {
-        return alternativePrefix;
-    }
-
-    /**
-     * @return The guild/servers ID.
-     */
-    public Long getGuildID() {
-        return guildID;
-    }
-
-    /**
-     * @return The channel ID for the bot-stuff channel.
-     */
-    public Long getBotStuffChannelId() {
-        return botStuffChannelId;
-    }
-
-    /**
-     * @return The channel ID for the basic events channel.
-     */
-    public Long getChannelIDBasicEvents() {
-        return channelIDBasicEvents;
-    }
-
-    /**
-     * @return The channel ID for the important events channel.
-     */
-    public Long getChannelIDImportantEvents() {
-        return channelIDImportantEvents;
-    }
-
-    /**
-     * @return The channel ID of the channel the bot logs deleted messages in.
-     */
-    public Long getChannelIDDeletedMessages() {
-        return channelIDDeletedMessages;
-    }
-
-    /**
-     * @return The channel ID of the bots debug channel.
-     */
-    public Long getChannelIDDebug() {
-        return channelIDDebug;
-    }
-
-    /**
-     * @return The channel ID for the bots console channel.
-     */
-    public Long getChannelIDConsole() {
-        return channelIDConsole;
-    }
-
-    /**
-     * @return The channel ID for the readme channel.
-     */
-    public Long getChannelIDReadme() {
-        return channelIDReadme;
-    }
-
-    /**
-     * @return The channel ID for the rules.
-     */
-    public Long getChannelIDRules() {
-        return channelIDRules;
-    }
-
-    /**
-     * @return The channel ID for requests channel.
-     */
-    public Long getChannelIDRequests() {
-        return channelIDRequests;
-    }
-
-    /**
-     * @return The channel ID for request-discussion.
-     */
-    public Long getChannelIDRequestsDiscussion() {
-        return channelIDRequestsDiscussion;
-    }
-
-    /**
-     * @return The channel ID of the channel we want to display forge update notifications in.
-     */
-    public Long getChannelIDForgeNotifier() {
-        return channelIDForgeNotifier;
-    }
-
-    /**
-     * @return The role ID of the Staff role.
-     */
-    public String getRoleStaff() {
-        return roleStaff;
-    }
-
-    /**
-     * @return The role ID of the Community Reps role.
-     */
-    public String getRoleCommunityRep() {
-        return roleCommunityRep;
-    }
-
-    /**
-     * @return The role ID of the Modder role.
-     */
-    public String getRoleModder() {
-        return roleModder;
-    }
-
-    /**
-     * @return The role ID of the Artist role.
-     */
-    public String getRoleArtist() {
-        return roleArtist;
-    }
-
-    /**
-     * @return The role ID of the Streamer role.
-     */
-    public String getRoleStreamer() {
-        return roleStreamer;
-    }
-
-    /**
-     * @return The role ID of the Modpack Maker role.
-     */
-    public String getRoleModpackMaker() {
-        return roleModpackMaker;
-    }
-
-    /**
-     * @return The ID of the Translator role.
-     */
-    public String getRoleTranslator() {
-        return roleTranslator;
-    }
-
-    /**
-     * @return The ID of the Event Notifications role.
-     */
-    public String getRoleEventNotifications() {
-        return roleEventNotifications;
-    }
-
-    /**
-     * @return The ID of the Booster role.
-     */
-    public String getRoleBooster() {
-        return roleBooster;
-    }
-
-    /**
-     * @return The ID of the public server player role.
-     */
-    public String getRolePublicServerPlayer() {
-        return rolePublicServerPlayer;
-    }
-
-    /**
-     * @return The ID of the muted role.
-     */
-    public String getRoleMuted() {
-        return roleMuted;
-    }
-
-    /**
-     * @return The ID of the request is bad emoticon.
-     */
-    public Long[] getEmoteIDsBad() {
-        return emoteIDsBad;
-    }
-
-    /**
-     * @return The ID of the request needs improvement emoticon.
-     */
-    public Long[] getEmoteIDsNeedsImprovement() {
-        return emoteIDsNeedsImprovement;
-    }
-
-    /**
-     * @return The ID of the request is good emoticon.
-     */
-    public Long[] getEmoteIDsGood() {
-        return emoteIDsGood;
-    }
-
-    /**
-     * @return The threshold of the request is bad emoticon.
-     */
-    public double getBadReactionThreshold() {
-        return badReactionThreshold;
-    }
-
-    /**
-     * @return The warning threshold of the request is bad emoticon.
-     */
-    public double getWarningBadReactionThreshold() {
-        return warningBadReactionThreshold;
-    }
+	private final CommentedFileConfig config;
+	private boolean newlyGenerated = false;
+
+	public BotConfig(Path configFile) {
+		this(configFile, TomlFormat.instance());
+	}
+
+	public BotConfig(Path configFile, ConfigFormat<? extends CommentedConfig> configFormat) {
+		this.config = CommentedFileConfig.builder(configFile, configFormat)
+			.autoreload()
+			.onFileNotFound((file, format) -> {
+				this.newlyGenerated = true;
+				//noinspection UnstableApiUsage
+				return FileNotFoundAction.copyData(Resources.getResource("default-config.toml")).run(file, format);
+			})
+			.preserveInsertionOrder()
+			.build();
+		config.load();
+	}
+
+	/**
+	 * Returns whether the configuration file was newly generated (e.g. the bot was run for the first time).
+	 *
+	 * @return If the config file was newly generated
+	 */
+	public boolean isNewlyGenerated() {
+		return newlyGenerated;
+	}
+
+	/**
+	 * Returns the raw {@link CommentedFileConfig} object.
+	 *
+	 * @return The raw config object
+	 */
+	public CommentedFileConfig getConfig() {
+		return config;
+	}
+
+	/**
+	 * Returns the configured bot token, or {@code null} if there is none configured.
+	 *
+	 * @return The configured bot token, or {@code null}
+	 */
+	@Nullable
+	public String getToken() {
+		return config.<String>getOptional("bot.token")
+			.filter(string -> string.indexOf('!') == -1 || string.isEmpty())
+			.orElse(null);
+	}
+
+	/**
+	 * Returns the snowflake ID of the bot's owner, or {@code null} is none is configured.
+	 * <p>
+	 * The bot owner has access to special owner-only commands.
+	 *
+	 * @return The snowflake ID of the bot owner, or {@code null}
+	 */
+	@Nullable
+	public String getOwnerID() {
+		return config.get("bot.owner");
+	}
+
+	/**
+	 * Returns the snowflake ID of the guild where this bot resides, or {@code 0L} is none is configured.
+	 *
+	 * @return The snowflake ID of the guild
+	 */
+	public long getGuildID() {
+		return SafeIdUtil.safeConvert(config.get("bot.guildId"));
+	}
+
+	/**
+	 * Returns the main commands prefix for bot commands.
+	 *
+	 * @return The main commands prefix
+	 */
+	public String getMainPrefix() {
+		return config.getOrElse("commands.prefix.main", "!mmd-");
+	}
+
+	/**
+	 * Returns the alternative commands prefix for bot commands.
+	 * <p>
+	 * This will usually be a shorter version of the {@linkplain #getMainPrefix() main commands prefix}, to be easier and
+	 * quicker to type out commands.
+	 *
+	 * @return The alternative commands prefix
+	 */
+	public String getAlternativePrefix() {
+		return config.getOrElse("commands.prefix.alternative", "!");
+	}
+
+	/**
+	 * Returns the table of channel aliases, in the form of an {@link UnmodifiableConfig}.
+	 * <p>
+	 * Channel aliases are used in channel snowflakes lists to substitute the actual channel snowflake ID with a human-readable
+	 * identifier.
+	 *
+	 * @return The table of channel aliases
+	 */
+	public Optional<UnmodifiableConfig> getChannelAliases() {
+		return config.getOptional("channels.aliases");
+	}
+
+	/**
+	 * Returns the snowflake ID of the given channel key based on the configuration, or {@code 0L} if none is configured.
+	 * <p>
+	 * The channel key consists of ASCII letters, optionally separated by periods/full stops ({@code .}) for connoting
+	 * categories.
+	 *
+	 * @param channelKey The channel key
+	 * @return The snowflake ID of the given channel key, or {@code 0L}
+	 */
+	public long getChannel(String channelKey) {
+		return SafeIdUtil.safeConvert(getAliased("channels." + channelKey, getChannelAliases()));
+	}
+
+	/**
+	 * Returns whether the given command is enabled.
+	 *
+	 * @param commandName The command name
+	 * @return If the command is enabled
+	 */
+	public boolean isEnabled(String commandName) {
+		return config.<Boolean>getOrElse("commands." + commandName + ".enabled", true);
+	}
+
+	/**
+	 * Returns the list of snowflake IDs of the channels where the given command is allowed to run in.
+	 *
+	 * @param commandName The command name
+	 * @return The list of snowflake IDs of allowed channels
+	 */
+	public List<Long> getAllowedChannels(String commandName) {
+		return getAliasedSnowflakeList("commands." + commandName + ".allowed_channels", getChannelAliases())
+			.orElseGet(Collections::emptyList);
+	}
+
+	/**
+	 * Returns whether the given command is allowed to run in the given channel.
+	 * <p>
+	 * If the allowed channels list for the command does not exist, then the command defaults to being allowed to run.
+	 * Otherwise, the command is only allowed to run if the channel ID is in the list of allowed channels for the command.
+	 *
+	 * @param commandName The command name
+	 * @param channelID   The snowflake ID of the channel
+	 * @return If the command is allowed to run in the channel
+	 */
+	public boolean isAllowed(String commandName, long channelID) {
+		final List<Long> allowedChannels = getAllowedChannels(commandName);
+		return allowedChannels.isEmpty() || allowedChannels.contains(channelID);
+	}
+
+	/**
+	 * Returns the snowflake ID of the given role key based on the configuration, or {@code 0L} if none is configured.
+	 * <p>
+	 * The role key consists of ASCII letters, optionally separated by periods/full stops ({@code .}) for connoting
+	 * categories.
+	 *
+	 * @param roleKey The role key
+	 * @return The snowflake ID of the given role key, or {@code 0L}
+	 */
+	public long getRole(String roleKey) {
+		return SafeIdUtil.safeConvert(config.getOrElse("roles." + roleKey, ""));
+	}
+
+	/**
+	 * Returns the list of snowflake IDs of the reaction emotes for bad requests.
+	 *
+	 * @return The list of snowflake IDs of bad request reaction emotes
+	 */
+	public List<Long> getBadRequestsReactions() {
+		return getSnowflakeList("requests.emotes.bad").orElseGet(Collections::emptyList);
+	}
+
+	/**
+	 * Returns the list of snowflake IDs of the reaction emotes for requests that need improvement.
+	 * <p>
+	 * These reaction emotes carry half the weight of the {@link #getBadRequestsReactions() bad requests reactions}.
+	 *
+	 * @return The list of snowflake IDs of needs improvement request reaction emotes
+	 */
+	public List<Long> getRequestsNeedsImprovementReactions() {
+		return getSnowflakeList("requests.emotes.needs_improvement").orElseGet(Collections::emptyList);
+	}
+
+	/**
+	 * Returns the list of snowflake IDs of the reaction emotes for good requests.
+	 *
+	 * @return The list of snowflake IDs of good request reaction emotes
+	 */
+	public List<Long> getGoodRequestsReactions() {
+		return getSnowflakeList("requests.emotes.good").orElseGet(Collections::emptyList);
+	}
+
+	/**
+	 * Returns the request reaction threshold before a user is warned of their request being potentially removed.
+	 *
+	 * @return The request warning threshold
+	 */
+	public double getRequestsWarningThreshold() {
+		return config.<Number>getOrElse("requests.thresholds.warning", 0.0d).doubleValue();
+	}
+
+	/**
+	 * Returns the request reaction threshold before a request is removed.
+	 *
+	 * @return The request removal threshold
+	 */
+	public double getRequestsRemovalThreshold() {
+		return config.<Number>getOrElse("requests.thresholds.removal", 0.0d).doubleValue();
+	}
+
+	private Optional<List<Long>> getSnowflakeList(String path) {
+		return config.<List<String>>getOptional(path)
+			.map(strings -> strings.stream()
+				.map(SafeIdUtil::safeConvert)
+				.filter(snowflake -> snowflake != 0)
+				.collect(Collectors.toList()));
+	}
+
+	@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+	private Optional<List<Long>> getAliasedSnowflakeList(String path, Optional<UnmodifiableConfig> aliases) {
+		return config.<List<String>>getOptional(path)
+			.filter(list -> !list.isEmpty())
+			.map(strings -> strings.stream()
+				.map(str -> aliases.flatMap(cfg -> cfg.<String>getOptional(str)).orElse(str))
+				.map(SafeIdUtil::safeConvert)
+				.filter(snowflake -> snowflake != 0)
+				.collect(Collectors.toList()));
+	}
+
+	@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+	private String getAliased(String key, Optional<UnmodifiableConfig> aliases) {
+		return config.<String>getOptional(key)
+			.map(str -> aliases.flatMap(cfg -> cfg.<String>getOptional(str)).orElse(str))
+			.orElse("");
+	}
 }

--- a/src/main/java/com/mcmoddev/mmdbot/events/users/EventNicknameChanged.java
+++ b/src/main/java/com/mcmoddev/mmdbot/events/users/EventNicknameChanged.java
@@ -29,8 +29,9 @@ public final class EventNicknameChanged extends ListenerAdapter {
         final User user = event.getUser();
         final EmbedBuilder embed = new EmbedBuilder();
         final Guild guild = event.getGuild();
-        final TextChannel channel = guild.getTextChannelById(MMDBot.getConfig().getChannelIDBasicEvents());
-        final Long guildId = guild.getIdLong();
+        final TextChannel channel = guild.getTextChannelById(MMDBot.getConfig().getChannel("events.basic"));
+        if (channel == null) return;
+        final long guildId = guild.getIdLong();
         String oldNick;
         String newNick;
 
@@ -65,7 +66,7 @@ public final class EventNicknameChanged extends ListenerAdapter {
             newNick = event.getNewNickname();
         }
 
-        if (MMDBot.getConfig().getGuildID().equals(guildId)) {
+        if (MMDBot.getConfig().getGuildID() == guildId) {
 
             embed.setColor(Color.YELLOW);
             embed.setTitle("Nickname Changed");

--- a/src/main/java/com/mcmoddev/mmdbot/events/users/EventRoleAdded.java
+++ b/src/main/java/com/mcmoddev/mmdbot/events/users/EventRoleAdded.java
@@ -33,8 +33,9 @@ public final class EventRoleAdded extends ListenerAdapter {
         final User user = event.getUser();
         final EmbedBuilder embed = new EmbedBuilder();
         final Guild guild = event.getGuild();
-        final Long guildId = guild.getIdLong();
-        final TextChannel channel = guild.getTextChannelById(MMDBot.getConfig().getChannelIDImportantEvents());
+        final long guildId = guild.getIdLong();
+        final TextChannel channel = guild.getTextChannelById(MMDBot.getConfig().getChannel("events.important"));
+        if (channel == null) return;
 
         Utils.sleepTimer();
 
@@ -59,7 +60,7 @@ public final class EventRoleAdded extends ListenerAdapter {
         final List<Role> addedRoles = new ArrayList<>(event.getRoles());
         previousRoles.removeAll(addedRoles);
 
-        if (MMDBot.getConfig().getGuildID().equals(guildId)) {
+        if (MMDBot.getConfig().getGuildID() == guildId) {
             embed.setColor(Color.YELLOW);
             embed.setTitle("User Role Added");
             embed.setThumbnail(user.getEffectiveAvatarUrl());

--- a/src/main/java/com/mcmoddev/mmdbot/events/users/EventRoleRemoved.java
+++ b/src/main/java/com/mcmoddev/mmdbot/events/users/EventRoleRemoved.java
@@ -33,8 +33,9 @@ public final class EventRoleRemoved extends ListenerAdapter {
         final User user = event.getUser();
         final EmbedBuilder embed = new EmbedBuilder();
         final Guild guild = event.getGuild();
-        final Long guildId = guild.getIdLong();
-        final TextChannel channel = guild.getTextChannelById(MMDBot.getConfig().getChannelIDImportantEvents());
+        final long guildId = guild.getIdLong();
+        final TextChannel channel = guild.getTextChannelById(MMDBot.getConfig().getChannel("events.important"));
+        if (channel == null) return;
 
         Utils.sleepTimer();
 
@@ -59,7 +60,7 @@ public final class EventRoleRemoved extends ListenerAdapter {
         final List<Role> removedRoles = new ArrayList<>(event.getRoles());
         previousRoles.removeAll(removedRoles);
 
-        if (MMDBot.getConfig().getGuildID().equals(guildId)) {
+        if (MMDBot.getConfig().getGuildID() == guildId) {
             embed.setColor(Color.YELLOW);
             embed.setTitle("User Role Removed");
             embed.setThumbnail(user.getEffectiveAvatarUrl());

--- a/src/main/java/com/mcmoddev/mmdbot/events/users/EventUserJoined.java
+++ b/src/main/java/com/mcmoddev/mmdbot/events/users/EventUserJoined.java
@@ -33,11 +33,12 @@ public final class EventUserJoined extends ListenerAdapter {
         final User user = event.getUser();
         final EmbedBuilder embed = new EmbedBuilder();
         final Guild guild = event.getGuild();
-        final Long guildId = guild.getIdLong();
-        final TextChannel channel = guild.getTextChannelById(MMDBot.getConfig().getChannelIDBasicEvents().toString());
+        final long guildId = guild.getIdLong();
+        final TextChannel channel = guild.getTextChannelById(MMDBot.getConfig().getChannel("events.basic"));
+        if (channel == null) return;
         final Member member = guild.getMember(user);
 
-        if (MMDBot.getConfig().getGuildID().equals(guildId)) {
+        if (MMDBot.getConfig().getGuildID() == guildId) {
             final List<Role> roles = Utils.getOldUserRoles(guild, user.getIdLong());
             if (member != null) {
                 for (Role role : roles) {
@@ -46,8 +47,10 @@ public final class EventUserJoined extends ListenerAdapter {
                     } catch (final HierarchyException e) {
                         MMDBot.LOGGER.info("Unable to give member {} role {}: {}", member.getId(), role.getId(), e.getMessage());
                         final Message consoleMessage = new MessageBuilder().appendFormat("Unable to give member %s role %s: %s", member.getAsMention(), role.getAsMention(), e.getMessage()).build();
-                        final TextChannel consoleChannel = guild.getTextChannelById(MMDBot.getConfig().getChannelIDConsole());
-                        if (consoleChannel != null) consoleChannel.sendMessage(consoleMessage).queue();
+                        final TextChannel consoleChannel = guild.getTextChannelById(MMDBot.getConfig().getChannel("console"));
+                        if (consoleChannel != null) {
+							consoleChannel.sendMessage(consoleMessage).queue();
+						}
                     }
                 }
             }

--- a/src/main/java/com/mcmoddev/mmdbot/updatenotifiers/fabric/FabricApiUpdateNotifier.java
+++ b/src/main/java/com/mcmoddev/mmdbot/updatenotifiers/fabric/FabricApiUpdateNotifier.java
@@ -23,8 +23,10 @@ public class FabricApiUpdateNotifier extends TimerTask {
 
         final long guildId = MMDBot.getConfig().getGuildID();
         final Guild guild = MMDBot.getInstance().getGuildById(guildId);
-        final long channelId = MMDBot.getConfig().getChannelIDForgeNotifier();
+        if (guild == null) return;
+        final long channelId = MMDBot.getConfig().getChannel("notifications.fabric");
         final TextChannel channel = guild.getTextChannelById(channelId);
+        if (channel == null) return;
 
         if (!lastLatest.equals(latest)) {
             lastLatest = latest;

--- a/src/main/java/com/mcmoddev/mmdbot/updatenotifiers/forge/ForgeUpdateNotifier.java
+++ b/src/main/java/com/mcmoddev/mmdbot/updatenotifiers/forge/ForgeUpdateNotifier.java
@@ -64,10 +64,12 @@ public class ForgeUpdateNotifier extends TimerTask {
                 // TODO: save this to disk to persist on restarts
                 lastForgeVersions = latest;
 
-                Long guildId = MMDBot.getConfig().getGuildID();
+                long guildId = MMDBot.getConfig().getGuildID();
                 final Guild guild = MMDBot.getInstance().getGuildById(guildId);
-                Long channelId = MMDBot.getConfig().getChannelIDForgeNotifier();
+				if (guild == null) return;
+                long channelId = MMDBot.getConfig().getChannel("notifications.forge");
                 final TextChannel channel = guild.getTextChannelById(channelId);
+                if (channel == null) return;
                 channel.sendMessage(embed.build()).queue();
             } else {
                 MMDBot.LOGGER.info("[ForgeUpdateNotifier] No Forge version update");

--- a/src/main/java/com/mcmoddev/mmdbot/updatenotifiers/game/MinecraftUpdateNotifier.java
+++ b/src/main/java/com/mcmoddev/mmdbot/updatenotifiers/game/MinecraftUpdateNotifier.java
@@ -26,8 +26,10 @@ public class MinecraftUpdateNotifier extends TimerTask {
 
         final long guildId = MMDBot.getConfig().getGuildID();
         final Guild guild = MMDBot.getInstance().getGuildById(guildId);
-        final long channelId = MMDBot.getConfig().getChannelIDForgeNotifier();
+        if (guild == null) return;
+        final long channelId = MMDBot.getConfig().getChannel("notifications.minecraft");
         final TextChannel channel = guild.getTextChannelById(channelId);
+        if (channel == null) return;
 
         if (!lastLatestStable.equals(latestStable)) {
             lastLatest = latest;

--- a/src/main/resources/default-config.toml
+++ b/src/main/resources/default-config.toml
@@ -1,0 +1,137 @@
+# The configuration file for MMDBot
+
+# For most keys, if it is left blank or an invalid value, the corresponding feature is disabled or cannot output
+
+# Configuration for the bot itself
+[bot]
+    # The token used for connecting to Discord.
+    # A value with the character '!' will be considered as being empty or unconfigured.
+    token = "!!! Insert token here !!!"
+
+    # The snowflake ID of a user, to be the owner of this bot.
+    # The owner has access to owner-only bot commands.
+    owner = ""
+
+    # The snowflake ID of the guild where this bot resides in
+    # Event logging will be filtered to only receive from this guild
+    guildId = ""
+
+# Configuration of channels
+[channels]
+    # The snowflake ID (or alias) of the bot console channel
+    # This channel will receive different bot messages
+    # Currently receives: failures to reapply roles on user rejoin, muting a user, unmuting a user
+    console = ""
+
+    # Configuration of event logging channels
+    # These channels will receive messages for different events within the guild
+    [channels.events]
+        # The snowflake ID (or alias) of the basic events logging channel
+        # Basic events include: user joining, user leaving, nickname changes
+        basic = ""
+
+        # The snowflake ID (or alias) of the important events logging channel
+        # Important events include: role added to user, role removed from user
+        important = ""
+
+        # The snowflake ID (or alias) of the requests deletion events logging channel
+        # Deletion of requests over the bad reaction threshold shall be logged here
+        requests_deletion = ""
+
+    # Configuration of requests-related channels
+    # Used for the requests bad reaction threshold system
+    [channels.requests]
+        # The snowflake (or alias) ID of the main requests channel
+        # This channel will be monitored by the bot for bad reactions, according to the bad reaction thresholds
+        main = ""
+
+        # The snowflake (or alias) ID of the requests discussion channel
+        # This channel will be used to alert users when their requests reaches the bad reaction thresholds
+        discussion = ""
+
+    # Configuration of channels used in informative bot commands
+    [channels.info]
+        # The snowflake ID (or alias) of the readme channel
+        # This channel is mentioned in the `readme` command
+        readme = ""
+
+        # The snowflake ID (or alias) of the rules channel
+        # This channel is mentioned in the `rules` command
+        rules = ""
+
+    # Configuration of version notification channels
+    # Version update notification messages will be sent to the specified channels
+    [channels.notifications]
+        # The snowflake ID (or alias) of the Forge notifications channel
+        forge = ""
+
+        # The snowflake ID (or alias) of the Fabric notifications channel
+        fabric = ""
+
+        # The snowflake ID (or alias) of the Minecraft notifications channel
+        minecraft = ""
+
+    # Configuration of channel aliases
+    # The path of a channel entry within this category may be used as a substitute for snowflake IDs of channels
+    # This allows for more human-readable configuration of other settings
+    [channels.aliases]
+        # A possible usage:
+        # bots_stuff=""
+
+# Configuration of roles
+[roles]
+    # The snowflake ID of the role affected by the `mute` and `unmute` commands
+    muted = ""
+
+    # Configuration of pingable and user-requestable roles
+    [roles.pings]
+        # The snowflake ID of the role for the `event-pings` command
+        event-pings = ""
+
+        # The snowflake ID of the role for the `toggle-mc-server-pings` command
+        toggle-mc-server-pings = ""
+
+# Configuration for the requests bad reaction threshold
+[requests]
+    # Configuration of the reaction emotes
+    [requests.emotes]
+        # The snowflake IDs of the reaction emotes for bad requests
+        bad = []
+
+        # The snowflake IDs of the reaction emotes for requests that need improvements
+        # These reaction emotes have half the weight of the reaction emotes for bad requests
+        needs_improvement = []
+
+        # The snowflake IDs of the reaction emotes for good requests
+        good = []
+
+    # Configuration of the requests reaction thresholds
+    # Request weights are calculated through the following formula: [bad + (needs_improvement * 0.5)] - good
+    # If a request falls below the given thresholds, then the indicated action is taken
+    [requests.thresholds]
+        # Threshold where a user is warned that their request may be removed with further negative reactions
+        warning = 3
+
+        # Threshold where the request is removed and the user is informed of its removal
+        removal = 5
+
+# Configuration for the bot commands
+[commands]
+    # Configuration of the commands prefixes
+    [commands.prefix]
+    # The main commands prefix for bot commands
+    main = "!mmd-"
+
+    # The alternative commands prefix for bot commands
+    # This can be used in lieu of the main commands prefix, for quicker and shorter usage of commands
+    alternative = "!"
+
+    # Bot commands may be individually configured; following is an example
+    [commands.build] # This configures the `build` command
+        # Whether the command is enabled and can be used
+        # If not configured, the default value is `true`
+        enabled = true
+
+        # A list of snowflake IDs (or aliases) for channels which this command is allowed to work in
+        # If the list is empty or not present, the default is to allow the command to work in all channels
+        allowed_channels = []


### PR DESCRIPTION
Hello! <sup>i just sunk what some would say is too much time into this</sup>

This PR moves the previously JSON-based config system to a TOML-based config system using [NightConfig][night_config], a powerful configuration library that supports TOML, YAML, JSON, and HOCON config formats (it's also used by [Minecraft Forge][mcforge]).

Because of how the config file is designed (and the tediousness of making a `ConfigSpec` that supports comments, like [what MinecraftForge has][forge_config_spec]), the config is not rigorously checked to be in the expected config format. However, this does give the benefit of being more flexible in usage (especially in regards to the custom user-defined sections like the commands config and the channel aliases).

Since we cannot enforce a spec for the config, there is a default config file (`default-config.toml`) in the resources that is copied over when the config file does not exist (i.e. the bot was run for the first time). This default config file contains comments explaining the different options in the config.

The implementation of the config in code is flexible enough to allow adding/using more config options in the future for other commands (like new role-giving commands, or other messages channels).

Also did some cleanup in this PR of other code, such as adding some null-safety checks, removing some unused methods, and reorganizing the previous code in `EventReactionAdded` to use `RestAction`s properly instead of using `complete()` and `submit()`.

[night_config]: https://github.com/TheElectronWill/night-config
[mcforge]: https://github.com/MinecraftForge/MinecraftForge
[forge_config_spec]: https://github.com/MinecraftForge/MinecraftForge/blob/1.16.x/src/main/java/net/minecraftforge/common/ForgeConfigSpec.java