### PR TITLE
Improve logging to console channel by using Logback

### DIFF
--- a/src/main/java/com/mcmoddev/mmdbot/MMDBot.java
+++ b/src/main/java/com/mcmoddev/mmdbot/MMDBot.java
@@ -32,7 +32,11 @@ import com.mcmoddev.mmdbot.events.users.EventUserJoined;
 import com.mcmoddev.mmdbot.events.users.EventUserLeft;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
+import net.dv8tion.jda.api.exceptions.ErrorHandler;
+import net.dv8tion.jda.api.exceptions.ErrorResponseException;
+import net.dv8tion.jda.api.requests.ErrorResponse;
 import net.dv8tion.jda.api.requests.GatewayIntent;
+import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.utils.cache.CacheFlag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,6 +46,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Our Main class.

--- a/src/main/java/com/mcmoddev/mmdbot/commands/staff/CmdMute.java
+++ b/src/main/java/com/mcmoddev/mmdbot/commands/staff/CmdMute.java
@@ -2,16 +2,18 @@ package com.mcmoddev.mmdbot.commands.staff;
 
 import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
-import com.mcmoddev.mmdbot.MMDBot;
 import com.mcmoddev.mmdbot.core.Utils;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.MessageChannel;
 import net.dv8tion.jda.api.entities.Role;
-import net.dv8tion.jda.api.entities.TextChannel;
 
 import java.util.concurrent.TimeUnit;
+
+import static com.mcmoddev.mmdbot.MMDBot.LOGGER;
+import static com.mcmoddev.mmdbot.MMDBot.getConfig;
+import static com.mcmoddev.mmdbot.logging.MMDMarkers.MUTING;
 
 public class CmdMute extends Command {
 
@@ -24,15 +26,15 @@ public class CmdMute extends Command {
 
     @Override
     protected void execute(CommandEvent event) {
-		if (!Utils.checkCommand(this, event)) return;
+        if (!Utils.checkCommand(this, event)) return;
         final Guild guild = event.getGuild();
         final MessageChannel channel = event.getChannel();
         final String[] args = event.getArgs().split(" ");
         final Member author = event.getGuild().getMember(event.getAuthor());
-		if (author == null) return;
+        if (author == null) return;
         final Member member = Utils.getMemberFromString(args[0], event.getGuild());
-        final Role mutedRole = guild.getRoleById(MMDBot.getConfig().getRole("muted"));
-        final TextChannel consoleChannel = guild.getTextChannelById(MMDBot.getConfig().getChannel("console"));
+        final long mutedRoleID = getConfig().getRole("muted");
+        final Role mutedRole = guild.getRoleById(mutedRoleID);
 
         if (author.hasPermission(Permission.KICK_MEMBERS)) {
             if (member == null) {
@@ -41,7 +43,7 @@ public class CmdMute extends Command {
             }
 
             if (mutedRole == null) {
-                MMDBot.LOGGER.error("Unable to find muted role!");
+                LOGGER.error(MUTING, "Unable to find muted role {}", mutedRoleID);
                 return;
             }
 
@@ -85,9 +87,7 @@ public class CmdMute extends Command {
             }
 
             channel.sendMessageFormat("Muted user %s for%s.", member.getAsMention(), timeString).queue();
-            if (consoleChannel != null) {
-				consoleChannel.sendMessageFormat("Muted user %s for%s", member.getAsMention(), timeString).queue();
-			}
+            LOGGER.info(MUTING, "User {} was muted by {} for{}", member, author, timeString);
         } else {
             channel.sendMessage("You do not have permission to use this command.").queue();
         }

--- a/src/main/java/com/mcmoddev/mmdbot/commands/staff/CmdUnmute.java
+++ b/src/main/java/com/mcmoddev/mmdbot/commands/staff/CmdUnmute.java
@@ -2,14 +2,16 @@ package com.mcmoddev.mmdbot.commands.staff;
 
 import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
-import com.mcmoddev.mmdbot.MMDBot;
 import com.mcmoddev.mmdbot.core.Utils;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.MessageChannel;
 import net.dv8tion.jda.api.entities.Role;
-import net.dv8tion.jda.api.entities.TextChannel;
+
+import static com.mcmoddev.mmdbot.MMDBot.LOGGER;
+import static com.mcmoddev.mmdbot.MMDBot.getConfig;
+import static com.mcmoddev.mmdbot.logging.MMDMarkers.MUTING;
 
 public class CmdUnmute extends Command {
 
@@ -22,15 +24,15 @@ public class CmdUnmute extends Command {
 
     @Override
     protected void execute(CommandEvent event) {
-		if (!Utils.checkCommand(this, event)) return;
+        if (!Utils.checkCommand(this, event)) return;
         final Guild guild = event.getGuild();
         final MessageChannel channel = event.getChannel();
         final String[] args = event.getArgs().split(" ");
         final Member author = event.getGuild().getMember(event.getAuthor());
         if (author == null) return;
         final Member member = Utils.getMemberFromString(args[0], event.getGuild());
-        final Role mutedRole = guild.getRoleById(MMDBot.getConfig().getRole("muted"));
-        final TextChannel consoleChannel = guild.getTextChannelById(MMDBot.getConfig().getChannel("console"));
+        final long mutedRoleID = getConfig().getRole("muted");
+        final Role mutedRole = guild.getRoleById(mutedRoleID);
 
         if (author.hasPermission(Permission.KICK_MEMBERS)) {
             if (member == null) {
@@ -39,15 +41,13 @@ public class CmdUnmute extends Command {
             }
 
             if (mutedRole == null) {
-                MMDBot.LOGGER.error("Unable to find muted role!");
+                LOGGER.error(MUTING, "Unable to find muted role {}", mutedRoleID);
                 return;
             }
 
             guild.removeRoleFromMember(member, mutedRole).queue();
             channel.sendMessageFormat("Unmuted user %s.", member.getAsMention()).queue();
-            if (consoleChannel != null) {
-				consoleChannel.sendMessageFormat("Unmuted user %s.", member.getAsMention()).queue();
-			}
+            LOGGER.info(MUTING, "User {} was unmuted by {}", member, author);
         } else {
             channel.sendMessage("You do not have permission to use this command.").queue();
         }

--- a/src/main/java/com/mcmoddev/mmdbot/events/EventReactionAdded.java
+++ b/src/main/java/com/mcmoddev/mmdbot/events/EventReactionAdded.java
@@ -2,6 +2,7 @@ package com.mcmoddev.mmdbot.events;
 
 import com.mcmoddev.mmdbot.MMDBot;
 import com.mcmoddev.mmdbot.core.Utils;
+import com.mcmoddev.mmdbot.logging.MMDMarkers;
 import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Message;
@@ -15,6 +16,10 @@ import net.dv8tion.jda.api.requests.RestAction;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import static com.mcmoddev.mmdbot.MMDBot.LOGGER;
+import static com.mcmoddev.mmdbot.MMDBot.getConfig;
+import static com.mcmoddev.mmdbot.logging.MMDMarkers.REQUESTS;
 
 /**
  *
@@ -31,21 +36,21 @@ public final class EventReactionAdded extends ListenerAdapter {
         final Guild guild = event.getGuild();
         final long guildId = guild.getIdLong();
         final TextChannel channel = event.getTextChannel();
-        final TextChannel discussionChannel = guild.getTextChannelById(MMDBot.getConfig().getChannel("requests.discussion"));
+        final TextChannel discussionChannel = guild.getTextChannelById(getConfig().getChannel("requests.discussion"));
 
         MessageHistory history = MessageHistory.getHistoryAround(channel, event.getMessageId()).limit(1).complete();
         final Message message = history.getMessageById(event.getMessageId());
         if (message == null) return;
         final User messageAuthor = message.getAuthor();
-		final double removalThreshold = MMDBot.getConfig().getRequestsRemovalThreshold();
-		final double warningThreshold = MMDBot.getConfig().getRequestsWarningThreshold();
+		final double removalThreshold = getConfig().getRequestsRemovalThreshold();
+		final double warningThreshold = getConfig().getRequestsWarningThreshold();
 		if (removalThreshold == 0 || warningThreshold == 0) return;
 
-        if (MMDBot.getConfig().getGuildID() == guildId && MMDBot.getConfig().getChannel("requests.main") == channel.getIdLong()) {
+        if (getConfig().getGuildID() == guildId && getConfig().getChannel("requests.main") == channel.getIdLong()) {
 
-        	final List<Long> badReactionsList = MMDBot.getConfig().getBadRequestsReactions();
-			final List<Long> goodReactionsList = MMDBot.getConfig().getGoodRequestsReactions();
-			final List<Long> needsImprovementReactionsList = MMDBot.getConfig().getRequestsNeedsImprovementReactions();
+        	final List<Long> badReactionsList = getConfig().getBadRequestsReactions();
+			final List<Long> goodReactionsList = getConfig().getGoodRequestsReactions();
+			final List<Long> needsImprovementReactionsList = getConfig().getRequestsNeedsImprovementReactions();
             final int badReactions = Utils.getNumberOfMatchingReactions(message, badReactionsList::contains);
             final int goodReactions = Utils.getNumberOfMatchingReactions(message, goodReactionsList::contains);
             final int needsImprovementReactions = Utils.getNumberOfMatchingReactions(message, needsImprovementReactionsList::contains);
@@ -53,6 +58,8 @@ public final class EventReactionAdded extends ListenerAdapter {
             final double requestScore = (badReactions + needsImprovementReactions * 0.5) - goodReactions;
 
             if (requestScore >= removalThreshold) {
+                LOGGER.info(REQUESTS, "Removed request from {} due to score of {} reaching removal threshold {}", messageAuthor, requestScore, removalThreshold);
+
 				final Message response = new MessageBuilder().append(messageAuthor.getAsMention()).append(", ")
 					.append("your request has been found to be low quality by community review and has been removed.\n")
 					.append("Please see other requests for how to do it correctly.\n")
@@ -62,7 +69,7 @@ public final class EventReactionAdded extends ListenerAdapter {
 
 				warnedMessages.remove(message);
 
-                final TextChannel logChannel = guild.getTextChannelById(MMDBot.getConfig().getChannel("events.requests_deletion"));
+                final TextChannel logChannel = guild.getTextChannelById(getConfig().getChannel("events.requests_deletion"));
                 if (logChannel != null) {
                     logChannel.sendMessage(String.format("Auto-deleted request from %s: %s", messageAuthor.getId(), message.getContentRaw())).queue();
                 }
@@ -81,6 +88,8 @@ public final class EventReactionAdded extends ListenerAdapter {
 					.queue();
 
             } else if (!warnedMessages.contains(message) && requestScore >= warningThreshold) {
+                LOGGER.info(REQUESTS, "Warned user {} due to their request (message id: {}) score of {} reaching warning threshold {}", messageAuthor, message.getId(), requestScore, warningThreshold);
+
                 final Message response = new MessageBuilder()
 					.append(messageAuthor.getAsMention()).append(", ")
                 	.append("your request is close to being removed by community review.\n")

--- a/src/main/java/com/mcmoddev/mmdbot/events/users/EventNicknameChanged.java
+++ b/src/main/java/com/mcmoddev/mmdbot/events/users/EventNicknameChanged.java
@@ -1,6 +1,5 @@
 package com.mcmoddev.mmdbot.events.users;
 
-import com.mcmoddev.mmdbot.MMDBot;
 import com.mcmoddev.mmdbot.core.Utils;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.audit.ActionType;
@@ -16,6 +15,10 @@ import java.awt.Color;
 import java.time.Instant;
 import java.util.List;
 
+import static com.mcmoddev.mmdbot.MMDBot.LOGGER;
+import static com.mcmoddev.mmdbot.MMDBot.getConfig;
+import static com.mcmoddev.mmdbot.logging.MMDMarkers.EVENTS;
+
 /**
  *
  */
@@ -29,7 +32,7 @@ public final class EventNicknameChanged extends ListenerAdapter {
         final User user = event.getUser();
         final EmbedBuilder embed = new EmbedBuilder();
         final Guild guild = event.getGuild();
-        final TextChannel channel = guild.getTextChannelById(MMDBot.getConfig().getChannel("events.basic"));
+        final TextChannel channel = guild.getTextChannelById(getConfig().getChannel("events.basic"));
         if (channel == null) return;
         final long guildId = guild.getIdLong();
         String oldNick;
@@ -66,7 +69,8 @@ public final class EventNicknameChanged extends ListenerAdapter {
             newNick = event.getNewNickname();
         }
 
-        if (MMDBot.getConfig().getGuildID() == guildId) {
+        if (getConfig().getGuildID() == guildId) {
+            LOGGER.info(EVENTS, "User {} changed nickname from {} to {}, changed by {}", user.getId(), oldNick, newNick, editorID);
 
             embed.setColor(Color.YELLOW);
             embed.setTitle("Nickname Changed");

--- a/src/main/java/com/mcmoddev/mmdbot/events/users/EventRoleAdded.java
+++ b/src/main/java/com/mcmoddev/mmdbot/events/users/EventRoleAdded.java
@@ -1,6 +1,5 @@
 package com.mcmoddev.mmdbot.events.users;
 
-import com.mcmoddev.mmdbot.MMDBot;
 import com.mcmoddev.mmdbot.core.Utils;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.audit.ActionType;
@@ -20,6 +19,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.mcmoddev.mmdbot.MMDBot.LOGGER;
+import static com.mcmoddev.mmdbot.MMDBot.getConfig;
+import static com.mcmoddev.mmdbot.logging.MMDMarkers.EVENTS;
+
 /**
  *
  */
@@ -34,7 +37,7 @@ public final class EventRoleAdded extends ListenerAdapter {
         final EmbedBuilder embed = new EmbedBuilder();
         final Guild guild = event.getGuild();
         final long guildId = guild.getIdLong();
-        final TextChannel channel = guild.getTextChannelById(MMDBot.getConfig().getChannel("events.important"));
+        final TextChannel channel = guild.getTextChannelById(getConfig().getChannel("events.important"));
         if (channel == null) return;
 
         Utils.sleepTimer();
@@ -60,7 +63,9 @@ public final class EventRoleAdded extends ListenerAdapter {
         final List<Role> addedRoles = new ArrayList<>(event.getRoles());
         previousRoles.removeAll(addedRoles);
 
-        if (MMDBot.getConfig().getGuildID() == guildId) {
+        if (getConfig().getGuildID() == guildId) {
+            LOGGER.info(EVENTS, "Role {} was added to user {} by {}", addedRoles, user, editor);
+
             embed.setColor(Color.YELLOW);
             embed.setTitle("User Role Added");
             embed.setThumbnail(user.getEffectiveAvatarUrl());

--- a/src/main/java/com/mcmoddev/mmdbot/events/users/EventRoleRemoved.java
+++ b/src/main/java/com/mcmoddev/mmdbot/events/users/EventRoleRemoved.java
@@ -1,6 +1,5 @@
 package com.mcmoddev.mmdbot.events.users;
 
-import com.mcmoddev.mmdbot.MMDBot;
 import com.mcmoddev.mmdbot.core.Utils;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.audit.ActionType;
@@ -20,6 +19,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.mcmoddev.mmdbot.MMDBot.LOGGER;
+import static com.mcmoddev.mmdbot.MMDBot.getConfig;
+import static com.mcmoddev.mmdbot.logging.MMDMarkers.EVENTS;
+
 /**
  *
  */
@@ -34,15 +37,15 @@ public final class EventRoleRemoved extends ListenerAdapter {
         final EmbedBuilder embed = new EmbedBuilder();
         final Guild guild = event.getGuild();
         final long guildId = guild.getIdLong();
-        final TextChannel channel = guild.getTextChannelById(MMDBot.getConfig().getChannel("events.important"));
+        final TextChannel channel = guild.getTextChannelById(getConfig().getChannel("events.important"));
         if (channel == null) return;
 
         Utils.sleepTimer();
 
         final AuditLogPaginationAction paginationAction = event.getGuild().retrieveAuditLogs()
-                .type(ActionType.MEMBER_ROLE_UPDATE)
-                .limit(1)
-                .cache(false);
+            .type(ActionType.MEMBER_ROLE_UPDATE)
+            .limit(1)
+            .cache(false);
 
         final List<AuditLogEntry> entries = paginationAction.complete();
 
@@ -60,7 +63,9 @@ public final class EventRoleRemoved extends ListenerAdapter {
         final List<Role> removedRoles = new ArrayList<>(event.getRoles());
         previousRoles.removeAll(removedRoles);
 
-        if (MMDBot.getConfig().getGuildID() == guildId) {
+        if (getConfig().getGuildID() == guildId) {
+            LOGGER.info(EVENTS, "Role {} was removed from user {} by {}", removedRoles, user, editor);
+
             embed.setColor(Color.YELLOW);
             embed.setTitle("User Role Removed");
             embed.setThumbnail(user.getEffectiveAvatarUrl());

--- a/src/main/java/com/mcmoddev/mmdbot/events/users/EventUserJoined.java
+++ b/src/main/java/com/mcmoddev/mmdbot/events/users/EventUserJoined.java
@@ -1,13 +1,10 @@
 package com.mcmoddev.mmdbot.events.users;
 
-import com.mcmoddev.mmdbot.MMDBot;
 import com.mcmoddev.mmdbot.core.Utils;
 import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.IMentionable;
 import net.dv8tion.jda.api.entities.Member;
-import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.entities.User;
@@ -19,6 +16,10 @@ import java.awt.Color;
 import java.time.Instant;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static com.mcmoddev.mmdbot.MMDBot.LOGGER;
+import static com.mcmoddev.mmdbot.MMDBot.getConfig;
+import static com.mcmoddev.mmdbot.logging.MMDMarkers.EVENTS;
 
 /**
  *
@@ -34,23 +35,20 @@ public final class EventUserJoined extends ListenerAdapter {
         final EmbedBuilder embed = new EmbedBuilder();
         final Guild guild = event.getGuild();
         final long guildId = guild.getIdLong();
-        final TextChannel channel = guild.getTextChannelById(MMDBot.getConfig().getChannel("events.basic"));
+        final TextChannel channel = guild.getTextChannelById(getConfig().getChannel("events.basic"));
         if (channel == null) return;
         final Member member = guild.getMember(user);
 
-        if (MMDBot.getConfig().getGuildID() == guildId) {
+        if (getConfig().getGuildID() == guildId) {
+            LOGGER.info(EVENTS, "User {} joined the guild", user.getId());
             final List<Role> roles = Utils.getOldUserRoles(guild, user.getIdLong());
             if (member != null) {
+                LOGGER.info(EVENTS, "Giving old roles to user {}: {}", user.getId(), roles);
                 for (Role role : roles) {
                     try {
                         guild.addRoleToMember(member, role).queue();
                     } catch (final HierarchyException e) {
-                        MMDBot.LOGGER.info("Unable to give member {} role {}: {}", member.getId(), role.getId(), e.getMessage());
-                        final Message consoleMessage = new MessageBuilder().appendFormat("Unable to give member %s role %s: %s", member.getAsMention(), role.getAsMention(), e.getMessage()).build();
-                        final TextChannel consoleChannel = guild.getTextChannelById(MMDBot.getConfig().getChannel("console"));
-                        if (consoleChannel != null) {
-							consoleChannel.sendMessage(consoleMessage).queue();
-						}
+                        LOGGER.warn(EVENTS, "Unable to give member {} role {}: {}", member.getId(), role.getId(), e.getMessage());
                     }
                 }
             }

--- a/src/main/java/com/mcmoddev/mmdbot/events/users/EventUserLeft.java
+++ b/src/main/java/com/mcmoddev/mmdbot/events/users/EventUserLeft.java
@@ -1,6 +1,5 @@
 package com.mcmoddev.mmdbot.events.users;
 
-import com.mcmoddev.mmdbot.MMDBot;
 import com.mcmoddev.mmdbot.core.Utils;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Guild;
@@ -18,6 +17,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.mcmoddev.mmdbot.MMDBot.LOGGER;
+import static com.mcmoddev.mmdbot.MMDBot.getConfig;
+import static com.mcmoddev.mmdbot.logging.MMDMarkers.*;
+
 /**
  *
  */
@@ -32,17 +35,18 @@ public final class EventUserLeft extends ListenerAdapter {
         final EmbedBuilder embed = new EmbedBuilder();
         final Guild guild = event.getGuild();
         final long guildId = guild.getIdLong();
-        final TextChannel channel = guild.getTextChannelById(MMDBot.getConfig().getChannel("events.basic"));
+        final TextChannel channel = guild.getTextChannelById(getConfig().getChannel("events.basic"));
         if (channel == null) return;
         final Member member = event.getMember();
-        List<Role> roles = new ArrayList<>();
-        if (member != null) {
-			roles = member.getRoles();
-		} else {
-			MMDBot.LOGGER.warn("Could not get roles of leaving user " + user.getAsTag() + ": " + user.getId());
-		}
 
-        if (MMDBot.getConfig().getGuildID() == guildId) {
+        if (getConfig().getGuildID() == guildId) {
+            LOGGER.info(EVENTS, "User {} left the guild", user.getId());
+            List<Role> roles = new ArrayList<>();
+            if (member != null) {
+                roles = member.getRoles();
+            } else {
+                LOGGER.warn(EVENTS, "Could not get roles of leaving user " + user.getAsTag() + ": " + user.getId());
+            }
             Utils.writeUserRoles(user.getIdLong(), roles);
             if (member != null) {
 				Utils.writeUserJoinTimes(user.getId(), member.getTimeJoined().toInstant());

--- a/src/main/java/com/mcmoddev/mmdbot/logging/ConsoleChannelAppender.java
+++ b/src/main/java/com/mcmoddev/mmdbot/logging/ConsoleChannelAppender.java
@@ -1,0 +1,65 @@
+package com.mcmoddev.mmdbot.logging;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AppenderBase;
+import ch.qos.logback.core.Layout;
+import com.mcmoddev.mmdbot.MMDBot;
+import com.mcmoddev.mmdbot.core.BotConfig;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.MessageBuilder;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.TextChannel;
+
+import java.util.Collections;
+
+/**
+ * A custom {@link ch.qos.logback.core.Appender} for logging to a Discord channel.
+ * <p>
+ * This appender may have an inner {@link Layout}, for formatting the message to be sent to the channel.
+ * Otherwise, {@link ILoggingEvent#getFormattedMessage()} will be sent.
+ *
+ * @see ConsoleChannelLayout
+ */
+public class ConsoleChannelAppender extends AppenderBase<ILoggingEvent> {
+    private boolean allowMentions;
+    private Layout<ILoggingEvent> layout;
+
+    /**
+     * Sets whether the Discord messages should allow mentions, i.e. ping any mentioned users and roles.
+     *
+     * @param allowMentions Whether to allow mentions
+     */
+    public void setAllowMentions(boolean allowMentions) {
+        this.allowMentions = allowMentions;
+    }
+
+    /**
+     * Sets the inner {@link Layout}, used for formatting the message to be sent.
+     *
+     * @param layout The layout
+     */
+    public void setLayout(Layout<ILoggingEvent> layout) {
+        this.layout = layout;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void append(final ILoggingEvent event) {
+        final JDA jda = MMDBot.getInstance();
+        final BotConfig config = MMDBot.getConfig();
+        if (jda != null && config != null) {
+            final Guild guild = jda.getGuildById(config.getGuildID());
+            if (guild == null) return;
+            final TextChannel channel = guild.getTextChannelById(config.getChannel("console"));
+            if (channel == null) return;
+            MessageBuilder builder = new MessageBuilder();
+            builder.append(layout != null ? layout.doLayout(event) : event.getFormattedMessage());
+            if (!allowMentions) {
+                builder.setAllowedMentions(Collections.emptyList());
+            }
+            channel.sendMessage(builder.build()).queue();
+        }
+    }
+}

--- a/src/main/java/com/mcmoddev/mmdbot/logging/ConsoleChannelLayout.java
+++ b/src/main/java/com/mcmoddev/mmdbot/logging/ConsoleChannelLayout.java
@@ -1,0 +1,137 @@
+package com.mcmoddev.mmdbot.logging;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.CoreConstants;
+import ch.qos.logback.core.LayoutBase;
+import com.google.common.collect.ImmutableMap;
+import net.dv8tion.jda.api.entities.IMentionable;
+import org.slf4j.helpers.MessageFormatter;
+
+import java.util.AbstractMap;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * A custom {@link ch.qos.logback.core.Layout} for logging to Discord channels.
+ * <p>
+ * For each logging level (except {@link Level#OFF} and {@link Level#ALL}, there is an associated emote, used for
+ * visual distinction of the log messages.
+ * <p>
+ * Any {@link IMentionable} in the {@linkplain ILoggingEvent#getArgumentArray() message formatting arguments}, even
+ * inside {@link Collection}s and {@link Map}s, are converted into string mentions using
+ * {@link IMentionable#getAsMention()}.
+ */
+public class ConsoleChannelLayout extends LayoutBase<ILoggingEvent> {
+    /**
+     * The emote used when the given {@link Level} does not a corresponding emote in {@link #LEVEL_TO_EMOTE}.
+     */
+    private static final String UNKNOWN_EMOTE = ":radio_button:";
+    /**
+     * An {@linkplain ImmutableMap immutable map} of {@link Level}s to emotes.
+     * <p>
+     * Used for visual distinction of log messages within the Discord console channel.
+     */
+    private static final ImmutableMap<Level, String> LEVEL_TO_EMOTE = ImmutableMap.<Level, String>builder()
+        .put(Level.ERROR, ":red_square:")
+        .put(Level.WARN, ":yellow_circle:")
+        .put(Level.INFO, ":white_medium_small_square:")
+        .put(Level.DEBUG, ":large_blue_diamond:")
+        .put(Level.TRACE, ":small_orange_diamond:")
+        .build();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String doLayout(final ILoggingEvent event) {
+        final StringBuilder builder = new StringBuilder();
+        builder
+            .append(LEVEL_TO_EMOTE.getOrDefault(event.getLevel(), UNKNOWN_EMOTE))
+            .append(" ")
+            .append(event.getLevel().toString())
+            .append(" [**")
+            .append(event.getLoggerName());
+        if (event.getMarker() != null) {
+            builder
+                .append("**/**")
+                .append(event.getMarker().getName());
+        }
+        builder
+            .append("**] - ")
+            .append(getFormattedMessage(event))
+            .append(CoreConstants.LINE_SEPARATOR);
+        return builder.toString();
+    }
+
+    /**
+     * Converts the given {@link ILoggingEvent} into a formatted message string, converting {@link IMentionable}s
+     * as needed.
+     *
+     * @param event The logging event
+     * @return The formatted message, with replaced mentions
+     * @see #tryConvertMentionables(Object)
+     */
+    private String getFormattedMessage(ILoggingEvent event) {
+        final Object[] arguments = event.getArgumentArray();
+        if (event.getArgumentArray() != null) {
+            Object[] newArgs = new Object[arguments.length];
+            for (int i = 0; i < arguments.length; i++) {
+                newArgs[i] = tryConvertMentionables(arguments[i]);
+            }
+
+            return MessageFormatter.arrayFormat(event.getMessage(), newArgs).getMessage();
+        }
+        return event.getFormattedMessage();
+    }
+
+    /**
+     * Tries to convert the given object (or any contained objects within) to
+     * {@linkplain IMentionable#getAsMention() string mentions}.
+     * <p>
+     * The rules for conversion are as follows:
+     * <ul>
+     *     <li>If the object is an {@link IMentionable}, cast and convert into mention, then return the new mention.</li>
+     *     <li>If the object is an {@link Collection}, call this method on all entries within the collection, then
+     *     return a new collection with those modified entries.
+     *     <p>If the object is a {@link Set}, then the returned collection is a {@code Set}. Otherwise, the returned
+     *     collection is a {@link List}.</p></li>
+     *     <li>If the object is a {@link Map}, call this method on all keys and values within the map, then return an
+     *     new {@link ImmutableMap} with those modified entries.</li>
+     *     <li>If the object is a {@link Map.Entry}, call this method on the key and value, then return a new
+     *     {@link AbstractMap.SimpleImmutableEntry} containing the modified key and value pair.</li>
+     *     <li>Otherwise, return the object unmodified.</li>
+     * </ul>
+     *
+     * @param obj The object
+     * @return The converted object, according to the conversion rules
+     */
+    private static Object tryConvertMentionables(Object obj) {
+        if (obj instanceof IMentionable) {
+            return ((IMentionable) obj).getAsMention();
+        } else if (obj instanceof Collection) {
+            final Stream<Object> stream = ((Collection<?>) obj).stream()
+                .map(ConsoleChannelLayout::tryConvertMentionables);
+            if (obj instanceof Set)
+                return stream.collect(Collectors.toSet());
+            return stream.collect(Collectors.toList());
+
+        } else if (obj instanceof Map) {
+            return ((Map<?, ?>) obj).entrySet().stream()
+                .map(entry -> new AbstractMap.SimpleImmutableEntry<>(
+                    tryConvertMentionables(entry.getKey()), tryConvertMentionables(entry.getValue())
+                ))
+                .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        } else if (obj instanceof Map.Entry) {
+            final Map.Entry<?, ?> entry = (Map.Entry<?, ?>) obj;
+            return new AbstractMap.SimpleImmutableEntry<>(tryConvertMentionables(entry.getKey()), tryConvertMentionables(entry.getValue()));
+
+        }
+        return obj;
+    }
+}

--- a/src/main/java/com/mcmoddev/mmdbot/logging/MMDMarkers.java
+++ b/src/main/java/com/mcmoddev/mmdbot/logging/MMDMarkers.java
@@ -1,0 +1,42 @@
+package com.mcmoddev.mmdbot.logging;
+
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
+
+/**
+ * Class for holding the {@link Marker}s used for logging.
+ */
+public class MMDMarkers {
+    /**
+     * The {@link Marker} for the {@link com.mcmoddev.mmdbot.updatenotifiers.fabric.FabricApiUpdateNotifier}.
+     */
+    public static final Marker NOTIFIER_FABRIC = MarkerFactory.getMarker("Notifier.Fabric");
+    /**
+     * The {@link Marker} for the {@link com.mcmoddev.mmdbot.updatenotifiers.forge.ForgeUpdateNotifier}.
+     */
+    public static final Marker NOTIFIER_FORGE = MarkerFactory.getMarker("Notifier.Forge");
+    /**
+     * The {@link Marker} for the {@link com.mcmoddev.mmdbot.updatenotifiers.game.MinecraftUpdateNotifier}.
+     */
+    public static final Marker NOTIFIER_MC = MarkerFactory.getMarker("Notifier.MC");
+
+    /**
+     * The {@link Marker} for the requests removal system.
+     *
+     * @see com.mcmoddev.mmdbot.events.EventReactionAdded
+     */
+    public static final Marker REQUESTS = MarkerFactory.getMarker("Requests");
+
+    /**
+     * The {@link Marker} for different guild-related events, such as role addition/removal or nickname changes.
+     */
+    public static final Marker EVENTS = MarkerFactory.getMarker("Events");
+
+    /**
+     * The {@link Marker} for the muting system.
+     *
+     * @see com.mcmoddev.mmdbot.commands.staff.CmdMute
+     * @see com.mcmoddev.mmdbot.commands.staff.CmdUnmute
+     */
+    public static final Marker MUTING = MarkerFactory.getMarker("Muting");
+}

--- a/src/main/java/com/mcmoddev/mmdbot/updatenotifiers/fabric/FabricApiUpdateNotifier.java
+++ b/src/main/java/com/mcmoddev/mmdbot/updatenotifiers/fabric/FabricApiUpdateNotifier.java
@@ -9,6 +9,10 @@ import java.awt.Color;
 import java.time.Instant;
 import java.util.TimerTask;
 
+import static com.mcmoddev.mmdbot.MMDBot.LOGGER;
+import static com.mcmoddev.mmdbot.MMDBot.getConfig;
+import static com.mcmoddev.mmdbot.logging.MMDMarkers.NOTIFIER_FABRIC;
+
 public class FabricApiUpdateNotifier extends TimerTask {
 
     private String lastLatest;
@@ -21,14 +25,15 @@ public class FabricApiUpdateNotifier extends TimerTask {
     public void run() {
         String latest = FabricVersionHelper.getLatestApi();
 
-        final long guildId = MMDBot.getConfig().getGuildID();
+        final long guildId = getConfig().getGuildID();
         final Guild guild = MMDBot.getInstance().getGuildById(guildId);
         if (guild == null) return;
-        final long channelId = MMDBot.getConfig().getChannel("notifications.fabric");
+        final long channelId = getConfig().getChannel("notifications.fabric");
         final TextChannel channel = guild.getTextChannelById(channelId);
         if (channel == null) return;
 
         if (!lastLatest.equals(latest)) {
+            LOGGER.info(NOTIFIER_FABRIC, "New Fabric API release found, from {} to {}", lastLatest, latest);
             lastLatest = latest;
 
             final EmbedBuilder embed = new EmbedBuilder();

--- a/src/main/java/com/mcmoddev/mmdbot/updatenotifiers/forge/ForgeUpdateNotifier.java
+++ b/src/main/java/com/mcmoddev/mmdbot/updatenotifiers/forge/ForgeUpdateNotifier.java
@@ -10,6 +10,10 @@ import java.awt.Color;
 import java.time.Instant;
 import java.util.TimerTask;
 
+import static com.mcmoddev.mmdbot.MMDBot.LOGGER;
+import static com.mcmoddev.mmdbot.MMDBot.getConfig;
+import static com.mcmoddev.mmdbot.logging.MMDMarkers.NOTIFIER_FORGE;
+
 public class ForgeUpdateNotifier extends TimerTask {
 
     private static final String CHANGELOG_URL_TEMPLATE = "https://files.minecraftforge.net/maven/net/minecraftforge/forge/%1$s-%2$s/forge-%1$s-%2$s-changelog.txt";
@@ -36,46 +40,53 @@ public class ForgeUpdateNotifier extends TimerTask {
 			embed.setColor(Color.ORANGE);
 			embed.setTimestamp(Instant.now());
 
+			StringBuilder logMsg = new StringBuilder(32);
 			if (latest.getLatest() != null) {
                 if (lastForgeVersions.getLatest() == null) {
 					embed.addField("Latest", String.format("*none* -> **%s**\n", latest.getLatest()), true);
 					embed.setDescription(Utils.makeHyperlink("Changelog", String.format(CHANGELOG_URL_TEMPLATE, mcVersion, latest.getLatest())));
                     changed = true;
+                    logMsg.append("Latest, from none to ").append(latest.getLatest());
                 } else if (!latest.getLatest().equals(lastForgeVersions.getLatest())) {
                     embed.addField("Latest", String.format("**%s** -> **%s**\n", lastForgeVersions.getLatest(), latest.getLatest()), true);
                     embed.setDescription(Utils.makeHyperlink("Changelog", String.format(CHANGELOG_URL_TEMPLATE, mcVersion, latest.getLatest())));
                     changed = true;
+                    logMsg.append("Latest, from ").append(lastForgeVersions.getLatest()).append(" to ").append(latest.getLatest());
                 }
             }
 
             if (latest.getRecommended() != null) {
+                if (logMsg.length() != 0) logMsg.append("; ");
                 if (lastForgeVersions.getRecommended() == null) {
                     embed.addField("Recommended", String.format("*none* -> **%s**\n", latest.getRecommended()), true);
                     embed.setDescription(Utils.makeHyperlink("Changelog", String.format(CHANGELOG_URL_TEMPLATE, mcVersion, latest.getRecommended())));
                     changed = true;
+                    logMsg.append("Recommended, from none to ").append(latest.getLatest());
                 } else if (!latest.getRecommended().equals(lastForgeVersions.getRecommended())) {
                     embed.addField("Recommended", String.format("**%s** -> **%s**\n", lastForgeVersions.getRecommended(), latest.getRecommended()), true);
                     embed.setDescription(Utils.makeHyperlink("Changelog", String.format(CHANGELOG_URL_TEMPLATE, mcVersion, latest.getRecommended())));
                     changed = true;
+                    logMsg.append("Recommended, from ").append(lastForgeVersions.getLatest()).append(" to ").append(latest.getLatest());
                 }
             }
 
             if (changed) {
+                LOGGER.info(NOTIFIER_FORGE, "New Forge version found for {}: {}", mcVersion, logMsg);
                 // TODO: save this to disk to persist on restarts
                 lastForgeVersions = latest;
 
-                long guildId = MMDBot.getConfig().getGuildID();
+                long guildId = getConfig().getGuildID();
                 final Guild guild = MMDBot.getInstance().getGuildById(guildId);
 				if (guild == null) return;
-                long channelId = MMDBot.getConfig().getChannel("notifications.forge");
+                long channelId = getConfig().getChannel("notifications.forge");
                 final TextChannel channel = guild.getTextChannelById(channelId);
                 if (channel == null) return;
                 channel.sendMessage(embed.build()).queue();
             } else {
-                MMDBot.LOGGER.info("[ForgeUpdateNotifier] No Forge version update");
+                LOGGER.info(NOTIFIER_FORGE, "No new Forge version found");
             }
         } catch (Exception e) {
-            MMDBot.LOGGER.error("[ForgeUpdateNotifier] Error running forge update notifier", e);
+            LOGGER.error(NOTIFIER_FORGE, "Error while running", e);
             e.printStackTrace();
         }
     }

--- a/src/main/java/com/mcmoddev/mmdbot/updatenotifiers/game/MinecraftUpdateNotifier.java
+++ b/src/main/java/com/mcmoddev/mmdbot/updatenotifiers/game/MinecraftUpdateNotifier.java
@@ -9,6 +9,10 @@ import java.awt.Color;
 import java.time.Instant;
 import java.util.TimerTask;
 
+import static com.mcmoddev.mmdbot.MMDBot.LOGGER;
+import static com.mcmoddev.mmdbot.MMDBot.getConfig;
+import static com.mcmoddev.mmdbot.logging.MMDMarkers.*;
+
 public class MinecraftUpdateNotifier extends TimerTask {
 
     private String lastLatest;
@@ -24,14 +28,15 @@ public class MinecraftUpdateNotifier extends TimerTask {
         String latest = MinecraftVersionHelper.getLatest();
         String latestStable = MinecraftVersionHelper.getLatestStable();
 
-        final long guildId = MMDBot.getConfig().getGuildID();
+        final long guildId = getConfig().getGuildID();
         final Guild guild = MMDBot.getInstance().getGuildById(guildId);
         if (guild == null) return;
-        final long channelId = MMDBot.getConfig().getChannel("notifications.minecraft");
+        final long channelId = getConfig().getChannel("notifications.minecraft");
         final TextChannel channel = guild.getTextChannelById(channelId);
         if (channel == null) return;
 
         if (!lastLatestStable.equals(latestStable)) {
+            LOGGER.info(NOTIFIER_MC, "New Minecraft release found, from {} to {}", lastLatest, latest);
             lastLatest = latest;
 
             final EmbedBuilder embed = new EmbedBuilder();
@@ -41,6 +46,7 @@ public class MinecraftUpdateNotifier extends TimerTask {
             embed.setTimestamp(Instant.now());
             channel.sendMessage(embed.build()).queue();
         } else if (!lastLatest.equals(latest)) {
+            LOGGER.info(NOTIFIER_MC, "New Minecraft snapshot found, from {} to {}", lastLatest, latest);
             lastLatest = latest;
 
             final EmbedBuilder embed = new EmbedBuilder();

--- a/src/main/resources/default-config.toml
+++ b/src/main/resources/default-config.toml
@@ -108,6 +108,7 @@
     # Configuration of the requests reaction thresholds
     # Request weights are calculated through the following formula: [bad + (needs_improvement * 0.5)] - good
     # If a request falls below the given thresholds, then the indicated action is taken
+    # If any of the two thresholds are disabled, then the whole warning and removal system is disabled
     [requests.thresholds]
         # Threshold where a user is warned that their request may be removed with further negative reactions
         warning = 3

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -10,24 +10,34 @@
         </rollingPolicy>
         <encoder>
             <pattern>
-                %nopex[%d{HH:mm:ss}] [%level] [%logger{0}]: %msg%n%ex
+                %nopex[%d{HH:mm:ss}] [%level] [%logger{0}/%marker]: %msg%n%ex
             </pattern>
         </encoder>
     </appender>
     <!--Log levels include ERROR, WARN, INFO, DEBUG, TRACE-->
-    <root level="INFO">
+    <root level="DEBUG">
         <appender-ref ref="FILE"/>
     </root>
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <pattern>
-                %d %green([%thread]) %highlight(%level) %logger{50} - %msg%n
+                %d %green([%thread]) %highlight(%level) %logger{50}/%marker - %msg%n
             </pattern>
         </encoder>
     </appender>
     <!--Log levels include ERROR, WARN, INFO, DEBUG, TRACE-->
     <root level="WARN">
         <appender-ref ref="CONSOLE"/>
+    </root>
+
+    <appender name="CHANNEL" class="com.mcmoddev.mmdbot.logging.ConsoleChannelAppender">
+        <allowMentions>false</allowMentions>
+        <layout class="com.mcmoddev.mmdbot.logging.ConsoleChannelLayout"/>
+    </appender>
+
+    <!--Log levels include ERROR, WARN, INFO, DEBUG, TRACE-->
+    <root level="INFO">
+        <appender-ref ref="CHANNEL"/>
     </root>
 </configuration>


### PR DESCRIPTION
Hello! <sup>mo' PRs, mo' problems</sup>

This PR improves the logging capabilities of the bot, and expands the use of the console channel.
[According to @ProxyNeko][proxy_convo], the previous versions of the bot had a feature of directing logging output of the bot to a channel in the discord guild, the console channel. When the bot was rewritten to use JDA, this feature was lost. This PR aims to bring back that functionality, using Logback.

Instead of an approach such as directing logger output to `System.out` and wrapping it with a tracing `PrintStream` that copies messages to be sent to the discord channel, I opted for using Logback's native functionality of [`Appender`s][logback_appender] and [`Layout`s][logback_layout]. _In brief, an `Appender` is responsible for writing the logging output from `ILoggingEvent`s, while a `Layout` allows customized converting of `ILoggingEvent`s to string messages._

This is achieved through `ConsoleChannelAppender` and `ConsoleChannelLayout`, respectively. 
`ConsoleChannelAppender` is responsible for sending the received logging events to the configured console channel. It may have an attached `Layout` (in which case it will use the layout to convert the messages), or not.
`ConsoleChannelLayout` is the companion to the custom appender; it formats the logging events into a more Discord friendly format, using reaction emotes/emojis to visually seperate logging events of different levels, using Markdown formatting, and converting any passed `IMentionable` formatting arguments to their mentions.

The `logback.xml` is adjusted to add the new appender and layout, and to adjust the `RollingFileAppender`'s logging level to include debug output.

_Notes:_
 * Due to some possible interactions between the console channel logging and JDA, setting the logging level for the console channel appender to lower than `INFO` may be problematic. I recommend that it _never_ be set to `TRACE`, and only to `DEBUG` upon further testing.
 * The reaction emotes are currently hardcoded into the layout, for performance. It can be converted to using the config instead, but I'd recommend implementing some amount of caching for that.
 * I'd recommend putting the console channel on permanent mute, to reduce annoyances of the constant messages.

[proxy_convo]: https://discord.com/channels/176780432371744769/572261616956211201/796555804379447336
[logback_appender]: http://logback.qos.ch/manual/appenders.html
[logback_layout]: http://logback.qos.ch/manual/layouts.html