### PR TITLE
Improve the commands config

### DIFF
--- a/src/main/java/com/mcmoddev/mmdbot/core/BotConfig.java
+++ b/src/main/java/com/mcmoddev/mmdbot/core/BotConfig.java
@@ -13,249 +13,294 @@ import javax.annotation.Nullable;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * The configuration holder for the bot.
  */
 public final class BotConfig {
-	private final CommentedFileConfig config;
-	private boolean newlyGenerated = false;
+    private final CommentedFileConfig config;
+    private boolean newlyGenerated = false;
 
-	public BotConfig(Path configFile) {
-		this(configFile, TomlFormat.instance());
-	}
+    public BotConfig(Path configFile) {
+        this(configFile, TomlFormat.instance());
+    }
 
-	public BotConfig(Path configFile, ConfigFormat<? extends CommentedConfig> configFormat) {
-		this.config = CommentedFileConfig.builder(configFile, configFormat)
-			.autoreload()
-			.onFileNotFound((file, format) -> {
-				this.newlyGenerated = true;
-				//noinspection UnstableApiUsage
-				return FileNotFoundAction.copyData(Resources.getResource("default-config.toml")).run(file, format);
-			})
-			.preserveInsertionOrder()
-			.build();
-		config.load();
-	}
+    public BotConfig(Path configFile, ConfigFormat<? extends CommentedConfig> configFormat) {
+        this.config = CommentedFileConfig.builder(configFile, configFormat)
+            .autoreload()
+            .onFileNotFound((file, format) -> {
+                this.newlyGenerated = true;
+                //noinspection UnstableApiUsage
+                return FileNotFoundAction.copyData(Resources.getResource("default-config.toml")).run(file, format);
+            })
+            .preserveInsertionOrder()
+            .build();
+        config.load();
+    }
 
-	/**
-	 * Returns whether the configuration file was newly generated (e.g. the bot was run for the first time).
-	 *
-	 * @return If the config file was newly generated
-	 */
-	public boolean isNewlyGenerated() {
-		return newlyGenerated;
-	}
+    /**
+     * Returns whether the configuration file was newly generated (e.g. the bot was run for the first time).
+     *
+     * @return If the config file was newly generated
+     */
+    public boolean isNewlyGenerated() {
+        return newlyGenerated;
+    }
 
-	/**
-	 * Returns the raw {@link CommentedFileConfig} object.
-	 *
-	 * @return The raw config object
-	 */
-	public CommentedFileConfig getConfig() {
-		return config;
-	}
+    /**
+     * Returns the raw {@link CommentedFileConfig} object.
+     *
+     * @return The raw config object
+     */
+    public CommentedFileConfig getConfig() {
+        return config;
+    }
 
-	/**
-	 * Returns the configured bot token, or {@code null} if there is none configured.
-	 *
-	 * @return The configured bot token, or {@code null}
-	 */
-	@Nullable
-	public String getToken() {
-		return config.<String>getOptional("bot.token")
-			.filter(string -> string.indexOf('!') == -1 || string.isEmpty())
-			.orElse(null);
-	}
+    /**
+     * Returns the configured bot token, or {@code null} if there is none configured.
+     *
+     * @return The configured bot token, or {@code null}
+     */
+    @Nullable
+    public String getToken() {
+        return config.<String>getOptional("bot.token")
+            .filter(string -> string.indexOf('!') == -1 || string.isEmpty())
+            .orElse(null);
+    }
 
-	/**
-	 * Returns the snowflake ID of the bot's owner, or {@code null} is none is configured.
-	 * <p>
-	 * The bot owner has access to special owner-only commands.
-	 *
-	 * @return The snowflake ID of the bot owner, or {@code null}
-	 */
-	@Nullable
-	public String getOwnerID() {
-		return config.get("bot.owner");
-	}
+    /**
+     * Returns the snowflake ID of the bot's owner.
+     * <p>
+     * The bot owner has access to special owner-only commands.
+     *
+     * @return The snowflake ID of the bot owner
+     */
+    public String getOwnerID() {
+        return getAliased("bot.owner", getAliases());
+    }
 
-	/**
-	 * Returns the snowflake ID of the guild where this bot resides, or {@code 0L} is none is configured.
-	 *
-	 * @return The snowflake ID of the guild
-	 */
-	public long getGuildID() {
-		return SafeIdUtil.safeConvert(config.get("bot.guildId"));
-	}
+    /**
+     * Returns the snowflake ID of the guild where this bot resides, or {@code 0L} is none is configured.
+     *
+     * @return The snowflake ID of the guild
+     */
+    public long getGuildID() {
+        return SafeIdUtil.safeConvert(getAliased("bot.guildId", getAliases()));
+    }
 
-	/**
-	 * Returns the main commands prefix for bot commands.
-	 *
-	 * @return The main commands prefix
-	 */
-	public String getMainPrefix() {
-		return config.getOrElse("commands.prefix.main", "!mmd-");
-	}
+    /**
+     * Returns the main commands prefix for bot commands.
+     *
+     * @return The main commands prefix
+     */
+    public String getMainPrefix() {
+        return config.getOrElse("commands.prefix.main", "!mmd-");
+    }
 
-	/**
-	 * Returns the alternative commands prefix for bot commands.
-	 * <p>
-	 * This will usually be a shorter version of the {@linkplain #getMainPrefix() main commands prefix}, to be easier and
-	 * quicker to type out commands.
-	 *
-	 * @return The alternative commands prefix
-	 */
-	public String getAlternativePrefix() {
-		return config.getOrElse("commands.prefix.alternative", "!");
-	}
+    /**
+     * Returns the alternative commands prefix for bot commands.
+     * <p>
+     * This will usually be a shorter version of the {@linkplain #getMainPrefix() main commands prefix}, to be easier and
+     * quicker to type out commands.
+     *
+     * @return The alternative commands prefix
+     */
+    public String getAlternativePrefix() {
+        return config.getOrElse("commands.prefix.alternative", "!");
+    }
 
-	/**
-	 * Returns the table of channel aliases, in the form of an {@link UnmodifiableConfig}.
-	 * <p>
-	 * Channel aliases are used in channel snowflakes lists to substitute the actual channel snowflake ID with a human-readable
-	 * identifier.
-	 *
-	 * @return The table of channel aliases
-	 */
-	public Optional<UnmodifiableConfig> getChannelAliases() {
-		return config.getOptional("channels.aliases");
-	}
+    /**
+     * Returns the table of aliases, in the form of an {@link UnmodifiableConfig}.
+     * <p>
+     * Aliases are used in entries that require snowflake IDs to substitute the ID with a human-readable
+     * identifier.
+     *
+     * @return The table of aliases
+     */
+    public Optional<UnmodifiableConfig> getAliases() {
+        return config.getOptional("aliases");
+    }
 
-	/**
-	 * Returns the snowflake ID of the given channel key based on the configuration, or {@code 0L} if none is configured.
-	 * <p>
-	 * The channel key consists of ASCII letters, optionally separated by periods/full stops ({@code .}) for connoting
-	 * categories.
-	 *
-	 * @param channelKey The channel key
-	 * @return The snowflake ID of the given channel key, or {@code 0L}
-	 */
-	public long getChannel(String channelKey) {
-		return SafeIdUtil.safeConvert(getAliased("channels." + channelKey, getChannelAliases()));
-	}
+    /**
+     * Returns the configured alias for the given snowflake ID, if any.
+     *
+     * @param snowflake The snowflake ID
+     * @return The alias for the given snowflake
+     */
+    public Optional<String> getAlias(long snowflake) {
+        return getAliases()
+            .flatMap(aliases -> aliases.entrySet().stream()
+                .filter(entry -> entry.getValue() instanceof String)
+                .filter(entry -> SafeIdUtil.safeConvert(entry.getValue()) == snowflake)
+                .findFirst()
+            )
+            .map(UnmodifiableConfig.Entry::getKey);
+    }
 
-	/**
-	 * Returns whether the given command is enabled.
-	 *
-	 * @param commandName The command name
-	 * @return If the command is enabled
-	 */
-	public boolean isEnabled(String commandName) {
-		return config.<Boolean>getOrElse("commands." + commandName + ".enabled", true);
-	}
+    /**
+     * Returns whether the given command is globally enabled for all guilds.
+     * <p>
+     * If there is no config entry for the command, this will default to returning {@code true}.
+     *
+     * @param commandName The command name
+     * @return If the command is globally enabled, or {@code true} if not configured
+     * @see #isEnabled(String, long)
+     */
+    public boolean isEnabled(String commandName) {
+        return config.<Boolean>getOrElse("commands." + commandName + ".enabled", true);
+    }
 
-	/**
-	 * Returns the list of snowflake IDs of the channels where the given command is allowed to run in.
-	 *
-	 * @param commandName The command name
-	 * @return The list of snowflake IDs of allowed channels
-	 */
-	public List<Long> getAllowedChannels(String commandName) {
-		return getAliasedSnowflakeList("commands." + commandName + ".allowed_channels", getChannelAliases())
-			.orElseGet(Collections::emptyList);
-	}
+    /**
+     * Returns whether the given command is enabled for the given guild.
+     * <p>
+     * If there is no config entry for the command and guild, this will default to returning the result of
+     * {@link #isEnabled(String)}.
+     *
+     * @param commandName The command name
+     * @param guildID     The guild's snowflake ID
+     * @return If the command is enabled for the guild, or the value of {@link #isEnabled(String)}
+     */
+    public boolean isEnabled(String commandName, long guildID) {
+        return config.<Boolean>getOptional(
+            "commands." + commandName + "."
+                + getAlias(guildID).orElseGet(() -> String.valueOf(guildID))
+                + ".enabled")
+            .orElseGet(() -> isEnabled(commandName));
+    }
 
-	/**
-	 * Returns whether the given command is allowed to run in the given channel.
-	 * <p>
-	 * If the allowed channels list for the command does not exist, then the command defaults to being allowed to run.
-	 * Otherwise, the command is only allowed to run if the channel ID is in the list of allowed channels for the command.
-	 *
-	 * @param commandName The command name
-	 * @param channelID   The snowflake ID of the channel
-	 * @return If the command is allowed to run in the channel
-	 */
-	public boolean isAllowed(String commandName, long channelID) {
-		final List<Long> allowedChannels = getAllowedChannels(commandName);
-		return allowedChannels.isEmpty() || allowedChannels.contains(channelID);
-	}
+    /**
+     * Returns the list of blocked channels for the command in the given guild.
+     *
+     * @param commandName The command name
+     * @param guildID     The guild's snowflake ID
+     * @return The list of blocked channels for the command
+     */
+    public List<Long> getBlockedChannels(String commandName, long guildID) {
+        return getAliasedSnowflakeList(
+            "commands." + commandName + "."
+                + getAlias(guildID).orElseGet(() -> String.valueOf(guildID))
+                + ".blocked_channels", getAliases())
+            .orElseGet(Collections::emptyList);
+    }
 
-	/**
-	 * Returns the snowflake ID of the given role key based on the configuration, or {@code 0L} if none is configured.
-	 * <p>
-	 * The role key consists of ASCII letters, optionally separated by periods/full stops ({@code .}) for connoting
-	 * categories.
-	 *
-	 * @param roleKey The role key
-	 * @return The snowflake ID of the given role key, or {@code 0L}
-	 */
-	public long getRole(String roleKey) {
-		return SafeIdUtil.safeConvert(config.getOrElse("roles." + roleKey, ""));
-	}
+    /**
+     * Returns the list of allowed channels for the command in the given guild.
+     *
+     * @param commandName The command name
+     * @param guildID     The guild's snowflake ID
+     * @return The list of allowed channels for the command
+     */
+    public List<Long> getAllowedChannels(String commandName, long guildID) {
+        return getAliasedSnowflakeList(
+            "commands." + commandName + "."
+                + getAlias(guildID).orElseGet(() -> String.valueOf(guildID))
+                + ".allowed_channels", getAliases())
+            .orElseGet(Collections::emptyList);
+    }
 
-	/**
-	 * Returns the list of snowflake IDs of the reaction emotes for bad requests.
-	 *
-	 * @return The list of snowflake IDs of bad request reaction emotes
-	 */
-	public List<Long> getBadRequestsReactions() {
-		return getSnowflakeList("requests.emotes.bad").orElseGet(Collections::emptyList);
-	}
+    /**
+     * Returns the snowflake ID of the given role key based on the configuration, or {@code 0L} if none is configured.
+     * <p>
+     * The role key consists of ASCII letters, optionally separated by periods/full stops ({@code .}) for connoting
+     * categories.
+     *
+     * @param roleKey The role key
+     * @return The snowflake ID of the given role key, or {@code 0L}
+     */
+    public long getRole(String roleKey) {
+        return SafeIdUtil.safeConvert(getAliased("roles." + roleKey, getAliases()));
+    }
 
-	/**
-	 * Returns the list of snowflake IDs of the reaction emotes for requests that need improvement.
-	 * <p>
-	 * These reaction emotes carry half the weight of the {@link #getBadRequestsReactions() bad requests reactions}.
-	 *
-	 * @return The list of snowflake IDs of needs improvement request reaction emotes
-	 */
-	public List<Long> getRequestsNeedsImprovementReactions() {
-		return getSnowflakeList("requests.emotes.needs_improvement").orElseGet(Collections::emptyList);
-	}
+    /**
+     * Returns the snowflake ID of the given channel key based on the configuration, or {@code 0L} if none is configured.
+     * <p>
+     * The channel key consists of ASCII letters, optionally separated by periods/full stops ({@code .}) for connoting
+     * categories.
+     *
+     * @param channelKey The channel key
+     * @return The snowflake ID of the given channel key, or {@code 0L}
+     */
+    public long getChannel(String channelKey) {
+        return SafeIdUtil.safeConvert(getAliased("channels." + channelKey, getAliases()));
+    }
 
-	/**
-	 * Returns the list of snowflake IDs of the reaction emotes for good requests.
-	 *
-	 * @return The list of snowflake IDs of good request reaction emotes
-	 */
-	public List<Long> getGoodRequestsReactions() {
-		return getSnowflakeList("requests.emotes.good").orElseGet(Collections::emptyList);
-	}
+    /**
+     * Returns the list of snowflake IDs of the reaction emotes for bad requests.
+     *
+     * @return The list of snowflake IDs of bad request reaction emotes
+     */
+    public List<Long> getBadRequestsReactions() {
+        return getAliasedSnowflakeList("requests.emotes.bad", getAliases())
+            .orElseGet(Collections::emptyList);
+    }
 
-	/**
-	 * Returns the request reaction threshold before a user is warned of their request being potentially removed.
-	 *
-	 * @return The request warning threshold
-	 */
-	public double getRequestsWarningThreshold() {
-		return config.<Number>getOrElse("requests.thresholds.warning", 0.0d).doubleValue();
-	}
+    /**
+     * Returns the list of snowflake IDs of the reaction emotes for requests that need improvement.
+     * <p>
+     * These reaction emotes carry half the weight of the {@link #getBadRequestsReactions() bad requests reactions}.
+     *
+     * @return The list of snowflake IDs of needs improvement request reaction emotes
+     */
+    public List<Long> getRequestsNeedsImprovementReactions() {
+        return getAliasedSnowflakeList("requests.emotes.needs_improvement", getAliases())
+            .orElseGet(Collections::emptyList);
+    }
 
-	/**
-	 * Returns the request reaction threshold before a request is removed.
-	 *
-	 * @return The request removal threshold
-	 */
-	public double getRequestsRemovalThreshold() {
-		return config.<Number>getOrElse("requests.thresholds.removal", 0.0d).doubleValue();
-	}
+    /**
+     * Returns the list of snowflake IDs of the reaction emotes for good requests.
+     *
+     * @return The list of snowflake IDs of good request reaction emotes
+     */
+    public List<Long> getGoodRequestsReactions() {
+        return getAliasedSnowflakeList("requests.emotes.good", getAliases())
+            .orElseGet(Collections::emptyList);
+    }
 
-	private Optional<List<Long>> getSnowflakeList(String path) {
-		return config.<List<String>>getOptional(path)
-			.map(strings -> strings.stream()
-				.map(SafeIdUtil::safeConvert)
-				.filter(snowflake -> snowflake != 0)
-				.collect(Collectors.toList()));
-	}
+    /**
+     * Returns the request reaction threshold before a user is warned of their request being potentially removed.
+     *
+     * @return The request warning threshold
+     */
+    public double getRequestsWarningThreshold() {
+        return config.<Number>getOrElse("requests.thresholds.warning", 0.0d).doubleValue();
+    }
 
-	@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-	private Optional<List<Long>> getAliasedSnowflakeList(String path, Optional<UnmodifiableConfig> aliases) {
-		return config.<List<String>>getOptional(path)
-			.filter(list -> !list.isEmpty())
-			.map(strings -> strings.stream()
-				.map(str -> aliases.flatMap(cfg -> cfg.<String>getOptional(str)).orElse(str))
-				.map(SafeIdUtil::safeConvert)
-				.filter(snowflake -> snowflake != 0)
-				.collect(Collectors.toList()));
-	}
+    /**
+     * Returns the request reaction threshold before a request is removed.
+     *
+     * @return The request removal threshold
+     */
+    public double getRequestsRemovalThreshold() {
+        return config.<Number>getOrElse("requests.thresholds.removal", 0.0d).doubleValue();
+    }
 
-	@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-	private String getAliased(String key, Optional<UnmodifiableConfig> aliases) {
-		return config.<String>getOptional(key)
-			.map(str -> aliases.flatMap(cfg -> cfg.<String>getOptional(str)).orElse(str))
-			.orElse("");
-	}
+    private Optional<List<Long>> getSnowflakeList(String path) {
+        return config.<List<String>>getOptional(path)
+            .map(strings -> strings.stream()
+                .map(SafeIdUtil::safeConvert)
+                .filter(snowflake -> snowflake != 0)
+                .collect(Collectors.toList()));
+    }
+
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    private Optional<List<Long>> getAliasedSnowflakeList(String path, Optional<UnmodifiableConfig> aliases) {
+        return config.<List<String>>getOptional(path)
+            .filter(list -> !list.isEmpty())
+            .map(strings -> strings.stream()
+                .map(str -> aliases.flatMap(cfg -> cfg.<String>getOptional(str)).orElse(str))
+                .map(SafeIdUtil::safeConvert)
+                .filter(snowflake -> snowflake != 0)
+                .collect(Collectors.toList()));
+    }
+
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    private String getAliased(String key, Optional<UnmodifiableConfig> aliases) {
+        return config.<String>getOptional(key)
+            .map(str -> aliases.flatMap(cfg -> cfg.<String>getOptional(str)).orElse(str))
+            .orElse("");
+    }
 }

--- a/src/main/resources/default-config.toml
+++ b/src/main/resources/default-config.toml
@@ -16,6 +16,14 @@
     # Event logging will be filtered to only receive from this guild
     guildId = ""
 
+# Configuration of aliases
+# Aliases may be used as substitutes in entries that require snowflake IDs, such as channel blocklists
+# This allows for more human-readable configuration of other settings
+# Note: this does not support sub tables (i.e. [aliases.categories])
+[aliases]
+    # Example usage:
+    # bots_stuff = "<snowflake ID>"
+
 # Configuration of channels
 [channels]
     # The snowflake ID (or alias) of the bot console channel
@@ -71,13 +79,6 @@
         # The snowflake ID (or alias) of the Minecraft notifications channel
         minecraft = ""
 
-    # Configuration of channel aliases
-    # The path of a channel entry within this category may be used as a substitute for snowflake IDs of channels
-    # This allows for more human-readable configuration of other settings
-    [channels.aliases]
-        # A possible usage:
-        # bots_stuff=""
-
 # Configuration of roles
 [roles]
     # The snowflake ID of the role affected by the `mute` and `unmute` commands
@@ -119,19 +120,30 @@
 [commands]
     # Configuration of the commands prefixes
     [commands.prefix]
-    # The main commands prefix for bot commands
-    main = "!mmd-"
+        # The main commands prefix for bot commands
+        main = "!mmd-"
 
-    # The alternative commands prefix for bot commands
-    # This can be used in lieu of the main commands prefix, for quicker and shorter usage of commands
-    alternative = "!"
+        # The alternative commands prefix for bot commands
+        # This can be used in lieu of the main commands prefix, for quicker and shorter usage of commands
+        alternative = "!"
 
     # Bot commands may be individually configured; following is an example
     [commands.build] # This configures the `build` command
-        # Whether the command is enabled and can be used
+        # Whether the command is globally enabled and can be used
         # If not configured, the default value is `true`
         enabled = true
 
-        # A list of snowflake IDs (or aliases) for channels which this command is allowed to work in
-        # If the list is empty or not present, the default is to allow the command to work in all channels
-        allowed_channels = []
+        # Commands may also be configured per-guild; following is an example
+        [commands.build.guild_alias_here] # Guild snowflake IDs also work instead of an alias
+            # Whether the command is enabled for this guild and can be used
+            # Overrides the global setting, if not present then defaults to the global setting
+            enabled = false
+
+            # List of snowflake IDs/aliases of channels or categories where this command is blocked
+            # If empty or not configured, then the command is not blocked in this guild
+            # Blocked channels/categories take priority over being allowed
+            blocked_channels = ["channel_in_general_category"]
+
+            # List of snowflake IDs/aliases of channels or categories where this command is allowed
+            # If empty or not configured, then the command is always allowed (subject to blocking)
+            allowed_channels = ["general_category", "bot_channel"]


### PR DESCRIPTION
Hello! <sup>another day, another PR</sup>

This PR improves the existing commands config to allow per-guild configuration of commands.
The new layout of the commands section can be seen in the `default-config.toml` (along with explanatory comments).
### List of changes:
* The channel aliases config has been generalized into an `aliases` config, which can be used in lieu of snowflake IDs in config entries.
  * Due to how the aliases are implemented, aliases cannot be categorized, i.e. putting aliases under `[aliases.your_category]` does not work.
* Commands can now be configured per-guild.
  * The per-guild configuration may use either snowflake IDs or an alias.
  * Guilds may have an `enabled` config entry, which overrides the global `enabled` setting for the command.
  * The previous global channel allowlist has been moved to being per-guild.
  * A new channel blocklist has been added.
  * The channel allowlists and blocklists also accept snowflake IDs for categories, to filter against channel categories. Channels outside a category must be individually configured.
  * The commands check has been modified to take into account the per-guild allowlist and blocklist and guild enable override.
    * The order of checks are: guild enable override, channel/category blocklist, channel/category allowlist.
    * The blocklist will take precedence over the allowlist: if a category is blocked, commands will not run in any channel inside, even if explicitly allowed by the allowlist.
  * The requests reaction emotes lists now also respect aliases.
  * The `BotConfig` class's formatting is fixed, to remove the tabs and replace with spaces.