### PR TITLE
Miscellaneous fixes and new features, related to commands and notifiers

### DIFF
--- a/src/main/java/com/mcmoddev/mmdbot/MMDBot.java
+++ b/src/main/java/com/mcmoddev/mmdbot/MMDBot.java
@@ -41,6 +41,8 @@ import javax.security.auth.login.LoginException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.HashSet;
 import java.util.Set;
@@ -69,7 +71,7 @@ public final class MMDBot {
     static {
         String version = MMDBot.class.getPackage().getImplementationVersion();
         if (version == null) {
-            version = "DEV " + DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(Instant.now());
+            version = "DEV " + DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(OffsetDateTime.now(ZoneOffset.UTC));
         }
         VERSION = version;
     }

--- a/src/main/java/com/mcmoddev/mmdbot/MMDBot.java
+++ b/src/main/java/com/mcmoddev/mmdbot/MMDBot.java
@@ -40,6 +40,8 @@ import org.slf4j.LoggerFactory;
 import javax.security.auth.login.LoginException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -56,8 +58,21 @@ public final class MMDBot {
 
     /**
      * The bots current version.
+     * <p>
+     * The version will be taken from the {@code Implementation-Version} attribute of the JAR manifest.
+     * If that is unavailable, the version shall be the combination of the string {@code "DEV "} and the the current
+     * date and time in {@link java.time.format.DateTimeFormatter#ISO_OFFSET_DATE_TIME}.
      */
-    public static final String VERSION = MMDBot.class.getPackage().getImplementationVersion();
+    public static final String VERSION;
+
+    // Gets the version from the JAR manifest, else defaults to the time the bot was started
+    static {
+        String version = MMDBot.class.getPackage().getImplementationVersion();
+        if (version != null) {
+            version = "DEV " + DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(Instant.now());
+        }
+        VERSION = version;
+    }
 
     /**
      * The issue tracker where bugs and crashes should be reported, and PR's made.

--- a/src/main/java/com/mcmoddev/mmdbot/MMDBot.java
+++ b/src/main/java/com/mcmoddev/mmdbot/MMDBot.java
@@ -68,7 +68,7 @@ public final class MMDBot {
     // Gets the version from the JAR manifest, else defaults to the time the bot was started
     static {
         String version = MMDBot.class.getPackage().getImplementationVersion();
-        if (version != null) {
+        if (version == null) {
             version = "DEV " + DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(Instant.now());
         }
         VERSION = version;

--- a/src/main/java/com/mcmoddev/mmdbot/core/BotConfig.java
+++ b/src/main/java/com/mcmoddev/mmdbot/core/BotConfig.java
@@ -201,6 +201,18 @@ public final class BotConfig {
     }
 
     /**
+     * Returns the list of hidden channels.
+     * <p>
+     * Hidden channels are channels which are not printed / hidden from the message when a command is run in a non-allowed channel.
+     *
+     * @return The list of hidden channels
+     */
+    public List<Long> getHiddenChannels() {
+        return getAliasedSnowflakeList("commands.hidden_channels", getAliases())
+            .orElseGet(Collections::emptyList);
+    }
+
+    /**
      * Returns the snowflake ID of the given role key based on the configuration, or {@code 0L} if none is configured.
      * <p>
      * The role key consists of ASCII letters, optionally separated by periods/full stops ({@code .}) for connoting

--- a/src/main/java/com/mcmoddev/mmdbot/core/BotConfig.java
+++ b/src/main/java/com/mcmoddev/mmdbot/core/BotConfig.java
@@ -213,6 +213,18 @@ public final class BotConfig {
     }
 
     /**
+     * Returns the list of roles exempt from the blocklists and allowlists of commands.
+     * <p>
+     * Users with these roles bypass the block and allow lists of commands, allowing them to run (enabled) commands in any channel.
+     *
+     * @return The roles exempt from channel checking
+     */
+    public List<Long> getChannelExemptRoles() {
+        return getAliasedSnowflakeList("commands.exempt_roles", getAliases())
+            .orElseGet(Collections::emptyList);
+    }
+
+    /**
      * Returns the snowflake ID of the given role key based on the configuration, or {@code 0L} if none is configured.
      * <p>
      * The role key consists of ASCII letters, optionally separated by periods/full stops ({@code .}) for connoting

--- a/src/main/java/com/mcmoddev/mmdbot/core/Utils.java
+++ b/src/main/java/com/mcmoddev/mmdbot/core/Utils.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.stream.Collectors;
@@ -340,5 +341,15 @@ public final class Utils {
             return blockedChannels.stream().anyMatch(id -> id == channelID);
         }
         return false; // If not from a guild, default not blocked
+    }
+
+    public static void getChannelIfPresent(long channelID, Consumer<TextChannel> consumer) {
+        final long guildID = getConfig().getGuildID();
+        final Guild guild = MMDBot.getInstance().getGuildById(guildID);
+        if (guild == null) return;
+        final TextChannel channel = guild.getTextChannelById(channelID);
+        if (channel != null) {
+            consumer.accept(channel);
+        }
     }
 }

--- a/src/main/java/com/mcmoddev/mmdbot/core/Utils.java
+++ b/src/main/java/com/mcmoddev/mmdbot/core/Utils.java
@@ -283,6 +283,16 @@ public final class Utils {
             return false;
         }
 
+        if (event.isFromType(ChannelType.TEXT)) {
+            final List<Long> exemptRoles = getConfig().getChannelExemptRoles();
+            if (event.getMember().getRoles().stream()
+                .map(ISnowflake::getIdLong)
+                .anyMatch(exemptRoles::contains)) {
+                // The member has a channel-checking-exempt role, bypass checking and allow the command
+                return true;
+            }
+        }
+
         if (isBlocked(command, event)) {
             event.getChannel()
                     .sendMessage("This command is blocked from running in this channel!")

--- a/src/main/java/com/mcmoddev/mmdbot/core/Utils.java
+++ b/src/main/java/com/mcmoddev/mmdbot/core/Utils.java
@@ -309,12 +309,21 @@ public final class Utils {
             }
 
             if (!allowed) {
+                final List<Long> hiddenChannels = getConfig().getHiddenChannels();
                 final String allowedChannelStr = allowedChannels.stream()
-                        .map(id -> "<#" + id + ">")
-                        .collect(Collectors.joining(", "));
+                    .filter(id -> !hiddenChannels.contains(id))
+                    .map(id -> "<#" + id + ">")
+                    .collect(Collectors.joining(", "));
+
+                StringBuilder str = new StringBuilder()
+                    .append("This command cannot be run in this channel");
+                if (!allowedChannelStr.isEmpty()) {
+                    str.append(", only in ")
+                        .append(allowedChannelStr);
+                }
                 event.getChannel() // TODO: remove the allowed channel string?
-                        .sendMessage("This command cannot be run in this channel, only in " + allowedChannelStr + "!")
-                        .queue();
+                    .sendMessage(str.append("!"))
+                    .queue();
                 return false;
             }
         }
@@ -343,6 +352,12 @@ public final class Utils {
         return false; // If not from a guild, default not blocked
     }
 
+    /**
+     * Calls the given consumer only if the channel with the given ID is present within the {@linkplain BotConfig#getGuildID() bot's guild}.
+     *
+     * @param channelID The channel ID
+     * @param consumer  The consumer of the channel
+     */
     public static void getChannelIfPresent(long channelID, Consumer<TextChannel> consumer) {
         final long guildID = getConfig().getGuildID();
         final Guild guild = MMDBot.getInstance().getGuildById(guildID);

--- a/src/main/java/com/mcmoddev/mmdbot/events/users/EventNicknameChanged.java
+++ b/src/main/java/com/mcmoddev/mmdbot/events/users/EventNicknameChanged.java
@@ -70,7 +70,7 @@ public final class EventNicknameChanged extends ListenerAdapter {
         }
 
         if (getConfig().getGuildID() == guildId) {
-            LOGGER.info(EVENTS, "User {} changed nickname from {} to {}, changed by {}", user.getId(), oldNick, newNick, editorID);
+            LOGGER.info(EVENTS, "User {} changed nickname from {} to {}, changed by {}({})", user, oldNick, newNick, editorTag, editorID);
 
             embed.setColor(Color.YELLOW);
             embed.setTitle("Nickname Changed");

--- a/src/main/java/com/mcmoddev/mmdbot/events/users/EventNicknameChanged.java
+++ b/src/main/java/com/mcmoddev/mmdbot/events/users/EventNicknameChanged.java
@@ -3,17 +3,13 @@ package com.mcmoddev.mmdbot.events.users;
 import com.mcmoddev.mmdbot.core.Utils;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.audit.ActionType;
-import net.dv8tion.jda.api.audit.AuditLogEntry;
 import net.dv8tion.jda.api.entities.Guild;
-import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.guild.member.update.GuildMemberUpdateNicknameEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
-import net.dv8tion.jda.api.requests.restaction.pagination.AuditLogPaginationAction;
 
 import java.awt.Color;
 import java.time.Instant;
-import java.util.List;
 
 import static com.mcmoddev.mmdbot.MMDBot.LOGGER;
 import static com.mcmoddev.mmdbot.MMDBot.getConfig;
@@ -29,61 +25,44 @@ public final class EventNicknameChanged extends ListenerAdapter {
      */
     @Override
     public void onGuildMemberUpdateNickname(final GuildMemberUpdateNicknameEvent event) {
-        final User user = event.getUser();
-        final EmbedBuilder embed = new EmbedBuilder();
+        final User target = event.getUser();
         final Guild guild = event.getGuild();
-        final TextChannel channel = guild.getTextChannelById(getConfig().getChannel("events.basic"));
-        if (channel == null) return;
-        final long guildId = guild.getIdLong();
-        String oldNick;
-        String newNick;
+        final long channelID = getConfig().getChannel("events.basic");
+        final String oldNick = event.getOldNickname() != null ? event.getOldNickname() : target.getName();
+        final String newNick = event.getNewNickname() != null ? event.getNewNickname() : target.getName();
 
-        Utils.sleepTimer();
+        if (getConfig().getGuildID() != guild.getIdLong())
+            return; // Make sure that we don't post if it's not related to 'our' guild
 
-        final AuditLogPaginationAction paginationAction = event.getGuild().retrieveAuditLogs()
+        Utils.getChannelIfPresent(channelID, channel ->
+            guild.retrieveAuditLogs()
                 .type(ActionType.MEMBER_UPDATE)
                 .limit(1)
-                .cache(false);
+                .cache(false)
+                .map(list -> list.get(0))
+                .flatMap(entry -> {
+                    final EmbedBuilder embed = new EmbedBuilder();
 
-        final List<AuditLogEntry> entries = paginationAction.complete();
+                    embed.setColor(Color.YELLOW);
+                    embed.setTitle("Nickname Changed");
+                    embed.setThumbnail(target.getEffectiveAvatarUrl());
+                    embed.addField("User:", target.getAsMention() + " (" + target.getId() + ")", true);
+                    embed.setTimestamp(Instant.now());
+                    if (entry.getTargetIdLong() != target.getIdLong()) {
+                        LOGGER.warn(EVENTS, "Inconsistency between target of retrieved audit log entry and actual nickname event target: retrieved is {}, but target is {}", target, entry.getUser());
+                    } else if (entry.getUser() != null) {
+                        final User editor = entry.getUser();
+                        embed.addField("Nickname Editor:", editor.getAsMention() + " (" + editor.getId() + ")", true);
+                        embed.addBlankField(true);
+                    }
+                    embed.addField("Old Nickname:", oldNick, true);
+                    embed.addField("New Nickname:", newNick, true);
 
-        final AuditLogEntry entry = entries.get(0);
-        final User editor = entry.getUser();
+                    LOGGER.info(EVENTS, "User {} changed nickname from {} to {}, by {}", target, oldNick, newNick, entry.getUser());
 
-        String editorID = "Unknown";
-        String editorTag = "Unknown";
-        if (editor != null) {
-            editorID = editor.getId();
-            editorTag = editor.getAsTag();
-        }
-
-        if (event.getOldNickname() == null) {
-            oldNick = user.getName();
-        } else {
-            oldNick = event.getOldNickname();
-        }
-
-        if (event.getNewNickname() == null) {
-            newNick = user.getName();
-        } else {
-            newNick = event.getNewNickname();
-        }
-
-        if (getConfig().getGuildID() == guildId) {
-            LOGGER.info(EVENTS, "User {} changed nickname from {} to {}, changed by {}({})", user, oldNick, newNick, editorTag, editorID);
-
-            embed.setColor(Color.YELLOW);
-            embed.setTitle("Nickname Changed");
-            embed.setThumbnail(user.getEffectiveAvatarUrl());
-            embed.addField("User:", user.getAsTag(), true);
-            embed.addField("User ID:", user.getId(), true);
-            embed.addField("Old Nickname:", oldNick, true);
-            embed.addField("New Nickname:", newNick, true);
-            embed.addField("Nickname Editor:", editorTag, true);
-            embed.addField("Nickname Editor ID:", editorID, true);
-            embed.setTimestamp(Instant.now());
-
-            channel.sendMessage(embed.build()).queue();
-        }
+                    return channel.sendMessage(embed.build());
+                })
+                .queue()
+        );
     }
 }

--- a/src/main/java/com/mcmoddev/mmdbot/events/users/EventRoleRemoved.java
+++ b/src/main/java/com/mcmoddev/mmdbot/events/users/EventRoleRemoved.java
@@ -3,15 +3,12 @@ package com.mcmoddev.mmdbot.events.users;
 import com.mcmoddev.mmdbot.core.Utils;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.audit.ActionType;
-import net.dv8tion.jda.api.audit.AuditLogEntry;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.IMentionable;
 import net.dv8tion.jda.api.entities.Role;
-import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberRoleRemoveEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
-import net.dv8tion.jda.api.requests.restaction.pagination.AuditLogPaginationAction;
 
 import java.awt.Color;
 import java.time.Instant;
@@ -33,50 +30,45 @@ public final class EventRoleRemoved extends ListenerAdapter {
      */
     @Override
     public void onGuildMemberRoleRemove(final GuildMemberRoleRemoveEvent event) {
-        final User user = event.getUser();
-        final EmbedBuilder embed = new EmbedBuilder();
+        final User target = event.getUser();
         final Guild guild = event.getGuild();
-        final long guildId = guild.getIdLong();
-        final TextChannel channel = guild.getTextChannelById(getConfig().getChannel("events.important"));
-        if (channel == null) return;
+        final long channelID = getConfig().getChannel("events.important");
 
-        Utils.sleepTimer();
+        if (getConfig().getGuildID() != guild.getIdLong())
+            return; // Make sure that we don't post if it's not related to 'our' guild
 
-        final AuditLogPaginationAction paginationAction = event.getGuild().retrieveAuditLogs()
+        Utils.getChannelIfPresent(channelID, channel ->
+            guild.retrieveAuditLogs()
                 .type(ActionType.MEMBER_ROLE_UPDATE)
                 .limit(1)
-                .cache(false);
+                .cache(false)
+                .map(list -> list.get(0))
+                .flatMap(entry -> {
+                    final List<Role> previousRoles = new ArrayList<>(event.getMember().getRoles());
+                    final List<Role> removedRoles = new ArrayList<>(event.getRoles());
+                    previousRoles.addAll(removedRoles); // Just if the member has already been updated
 
-        final List<AuditLogEntry> entries = paginationAction.complete();
+                    final EmbedBuilder embed = new EmbedBuilder();
 
-        final AuditLogEntry entry = entries.get(0);
-        final User editor = entry.getUser();
+                    embed.setColor(Color.YELLOW);
+                    embed.setTitle("User Role(s) Removed");
+                    embed.setThumbnail(target.getEffectiveAvatarUrl());
+                    embed.addField("User:", target.getAsMention() + " (" + target.getId() + ")", true);
+                    if (entry.getTargetIdLong() != target.getIdLong()) {
+                        LOGGER.warn(EVENTS, "Inconsistency between target of retrieved audit log entry and actual role event target: retrieved is {}, but target is {}", target, entry.getUser());
+                    } else if (entry.getUser() != null) {
+                        final User editor = entry.getUser();
+                        embed.addField("Editor:", editor.getAsMention() + " (" + editor.getId() + ")", true);
+                    }
+                    embed.addField("Previous Role(s):", previousRoles.stream().map(IMentionable::getAsMention).collect(Collectors.joining(" ")), false);
+                    embed.addField("Removed Role(s):", removedRoles.stream().map(IMentionable::getAsMention).collect(Collectors.joining(" ")), false);
+                    embed.setTimestamp(Instant.now());
 
-        String editorID = "Unknown";
-        String editorTag = "Unknown";
-        if (editor != null) {
-            editorID = editor.getId();
-            editorTag = editor.getAsTag();
-        }
+                    LOGGER.info(EVENTS, "Role(s) {} was removed from user {} by {}", removedRoles, target, entry.getUser());
 
-        final List<Role> previousRoles = new ArrayList<>(event.getMember().getRoles());
-        final List<Role> removedRoles = new ArrayList<>(event.getRoles());
-        previousRoles.removeAll(removedRoles);
-
-        if (getConfig().getGuildID() == guildId) {
-            LOGGER.info(EVENTS, "Role {} was removed from user {} by {}", removedRoles, user, editor);
-
-            embed.setColor(Color.YELLOW);
-            embed.setTitle("User Role Removed");
-            embed.setThumbnail(user.getEffectiveAvatarUrl());
-            embed.addField("User:", user.getAsTag(), true);
-            embed.addField("User ID:", user.getId(), true);
-            embed.addField("Edited By:", editorTag, true);
-            embed.addField("Editor ID:", editorID, true);
-            embed.addField("Previous Roles:", previousRoles.stream().map(IMentionable::getAsMention).collect(Collectors.joining()), false);
-            embed.addField("Removed Roles:", removedRoles.stream().map(IMentionable::getAsMention).collect(Collectors.joining()), false);
-            embed.setTimestamp(Instant.now());
-            channel.sendMessage(embed.build()).queue();
-        }
+                    return channel.sendMessage(embed.build());
+                })
+                .queue()
+        );
     }
 }

--- a/src/main/java/com/mcmoddev/mmdbot/events/users/EventUserJoined.java
+++ b/src/main/java/com/mcmoddev/mmdbot/events/users/EventUserJoined.java
@@ -40,15 +40,15 @@ public final class EventUserJoined extends ListenerAdapter {
         final Member member = guild.getMember(user);
 
         if (getConfig().getGuildID() == guildId) {
-            LOGGER.info(EVENTS, "User {} joined the guild", user.getId());
+            LOGGER.info(EVENTS, "User {} joined the guild", user);
             final List<Role> roles = Utils.getOldUserRoles(guild, user.getIdLong());
             if (member != null) {
-                LOGGER.info(EVENTS, "Giving old roles to user {}: {}", user.getId(), roles);
+                LOGGER.info(EVENTS, "Giving old roles to user {}: {}", user, roles);
                 for (Role role : roles) {
                     try {
                         guild.addRoleToMember(member, role).queue();
                     } catch (final HierarchyException e) {
-                        LOGGER.warn(EVENTS, "Unable to give member {} role {}: {}", member.getId(), role.getId(), e.getMessage());
+                        LOGGER.warn(EVENTS, "Unable to give member {} role {}: {}", member, role, e.getMessage());
                     }
                 }
             }

--- a/src/main/java/com/mcmoddev/mmdbot/events/users/EventUserLeft.java
+++ b/src/main/java/com/mcmoddev/mmdbot/events/users/EventUserLeft.java
@@ -40,12 +40,12 @@ public final class EventUserLeft extends ListenerAdapter {
         final Member member = event.getMember();
 
         if (getConfig().getGuildID() == guildId) {
-            LOGGER.info(EVENTS, "User {} left the guild", user.getId());
+            LOGGER.info(EVENTS, "User {} left the guild", user);
             List<Role> roles = new ArrayList<>();
             if (member != null) {
                 roles = member.getRoles();
             } else {
-                LOGGER.warn(EVENTS, "Could not get roles of leaving user " + user.getAsTag() + ": " + user.getId());
+                LOGGER.warn(EVENTS, "Could not get roles of leaving user {}", user);
             }
             Utils.writeUserRoles(user.getIdLong(), roles);
             if (member != null) {

--- a/src/main/java/com/mcmoddev/mmdbot/updatenotifiers/fabric/FabricApiUpdateNotifier.java
+++ b/src/main/java/com/mcmoddev/mmdbot/updatenotifiers/fabric/FabricApiUpdateNotifier.java
@@ -1,9 +1,7 @@
 package com.mcmoddev.mmdbot.updatenotifiers.fabric;
 
-import com.mcmoddev.mmdbot.MMDBot;
+import com.mcmoddev.mmdbot.core.Utils;
 import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.entities.Guild;
-import net.dv8tion.jda.api.entities.TextChannel;
 
 import java.awt.Color;
 import java.time.Instant;
@@ -23,25 +21,25 @@ public class FabricApiUpdateNotifier extends TimerTask {
 
     @Override
     public void run() {
+        LOGGER.debug(NOTIFIER_FABRIC, "Checking for new Fabric API versions...");
         String latest = FabricVersionHelper.getLatestApi();
 
-        final long guildId = getConfig().getGuildID();
-        final Guild guild = MMDBot.getInstance().getGuildById(guildId);
-        if (guild == null) return;
         final long channelId = getConfig().getChannel("notifications.fabric");
-        final TextChannel channel = guild.getTextChannelById(channelId);
-        if (channel == null) return;
 
         if (!lastLatest.equals(latest)) {
             LOGGER.info(NOTIFIER_FABRIC, "New Fabric API release found, from {} to {}", lastLatest, latest);
             lastLatest = latest;
 
-            final EmbedBuilder embed = new EmbedBuilder();
-            embed.setTitle("New Fabric API release available!");
-            embed.setDescription(latest);
-            embed.setColor(Color.WHITE);
-            embed.setTimestamp(Instant.now());
-            channel.sendMessage(embed.build()).queue();
+            Utils.getChannelIfPresent(channelId, channel -> {
+                final EmbedBuilder embed = new EmbedBuilder();
+                embed.setTitle("New Fabric API release available!");
+                embed.setDescription(latest);
+                embed.setColor(Color.WHITE);
+                embed.setTimestamp(Instant.now());
+                channel.sendMessage(embed.build()).queue();
+            });
+        } else {
+            LOGGER.debug(NOTIFIER_FABRIC, "No new Fabric API version found");
         }
 
         lastLatest = latest;

--- a/src/main/java/com/mcmoddev/mmdbot/updatenotifiers/forge/ForgeUpdateNotifier.java
+++ b/src/main/java/com/mcmoddev/mmdbot/updatenotifiers/forge/ForgeUpdateNotifier.java
@@ -1,10 +1,7 @@
 package com.mcmoddev.mmdbot.updatenotifiers.forge;
 
-import com.mcmoddev.mmdbot.MMDBot;
 import com.mcmoddev.mmdbot.core.Utils;
 import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.entities.Guild;
-import net.dv8tion.jda.api.entities.TextChannel;
 
 import java.awt.Color;
 import java.time.Instant;
@@ -29,6 +26,7 @@ public class ForgeUpdateNotifier extends TimerTask {
     @Override
     public void run() {
         try {
+            LOGGER.debug(NOTIFIER_FORGE, "Checking for new Forge versions...");
             mcVersion = ForgeVersionHelper.getLatestMcVersionForgeVersions().getMcVersion();
 
             ForgeVersion latest = ForgeVersionHelper.getForgeVersionsForMcVersion(mcVersion);
@@ -75,15 +73,10 @@ public class ForgeUpdateNotifier extends TimerTask {
                 // TODO: save this to disk to persist on restarts
                 lastForgeVersions = latest;
 
-                long guildId = getConfig().getGuildID();
-                final Guild guild = MMDBot.getInstance().getGuildById(guildId);
-                if (guild == null) return;
-                long channelId = getConfig().getChannel("notifications.forge");
-                final TextChannel channel = guild.getTextChannelById(channelId);
-                if (channel == null) return;
-                channel.sendMessage(embed.build()).queue();
+                Utils.getChannelIfPresent(getConfig().getChannel("notifications.forge"),
+                    channel -> channel.sendMessage(embed.build()).queue());
             } else {
-                LOGGER.info(NOTIFIER_FORGE, "No new Forge version found");
+                LOGGER.debug(NOTIFIER_FORGE, "No new Forge version found");
             }
         } catch (Exception e) {
             LOGGER.error(NOTIFIER_FORGE, "Error while running", e);

--- a/src/main/java/com/mcmoddev/mmdbot/updatenotifiers/game/MinecraftUpdateNotifier.java
+++ b/src/main/java/com/mcmoddev/mmdbot/updatenotifiers/game/MinecraftUpdateNotifier.java
@@ -1,9 +1,7 @@
 package com.mcmoddev.mmdbot.updatenotifiers.game;
 
-import com.mcmoddev.mmdbot.MMDBot;
+import com.mcmoddev.mmdbot.core.Utils;
 import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.entities.Guild;
-import net.dv8tion.jda.api.entities.TextChannel;
 
 import java.awt.Color;
 import java.time.Instant;
@@ -25,36 +23,35 @@ public class MinecraftUpdateNotifier extends TimerTask {
 
     @Override
     public void run() {
+        LOGGER.debug(NOTIFIER_MC, "Checking for new Minecraft versions...");
         String latest = MinecraftVersionHelper.getLatest();
         String latestStable = MinecraftVersionHelper.getLatestStable();
-
-        final long guildId = getConfig().getGuildID();
-        final Guild guild = MMDBot.getInstance().getGuildById(guildId);
-        if (guild == null) return;
         final long channelId = getConfig().getChannel("notifications.minecraft");
-        final TextChannel channel = guild.getTextChannelById(channelId);
-        if (channel == null) return;
 
         if (!lastLatestStable.equals(latestStable)) {
             LOGGER.info(NOTIFIER_MC, "New Minecraft release found, from {} to {}", lastLatest, latest);
-            lastLatest = latest;
 
-            final EmbedBuilder embed = new EmbedBuilder();
-            embed.setTitle("New Minecraft release available!");
-            embed.setDescription(latest);
-            embed.setColor(Color.GREEN);
-            embed.setTimestamp(Instant.now());
-            channel.sendMessage(embed.build()).queue();
+            Utils.getChannelIfPresent(channelId, channel -> {
+                final EmbedBuilder embed = new EmbedBuilder();
+                embed.setTitle("New Minecraft release available!");
+                embed.setDescription(latest);
+                embed.setColor(Color.GREEN);
+                embed.setTimestamp(Instant.now());
+                channel.sendMessage(embed.build()).queue();
+            });
         } else if (!lastLatest.equals(latest)) {
             LOGGER.info(NOTIFIER_MC, "New Minecraft snapshot found, from {} to {}", lastLatest, latest);
-            lastLatest = latest;
 
-            final EmbedBuilder embed = new EmbedBuilder();
-            embed.setTitle("New Minecraft snapshot available!");
-            embed.setDescription(latest);
-            embed.setColor(Color.ORANGE);
-            embed.setTimestamp(Instant.now());
-            channel.sendMessage(embed.build()).queue();
+            Utils.getChannelIfPresent(channelId, channel -> {
+                final EmbedBuilder embed = new EmbedBuilder();
+                embed.setTitle("New Minecraft snapshot available!");
+                embed.setDescription(latest);
+                embed.setColor(Color.ORANGE);
+                embed.setTimestamp(Instant.now());
+                channel.sendMessage(embed.build()).queue();
+            });
+        } else {
+            LOGGER.debug(NOTIFIER_MC, "No new Minecraft version found");
         }
 
         lastLatest = latest;

--- a/src/main/java/com/mcmoddev/mmdbot/updatenotifiers/game/MinecraftUpdateNotifier.java
+++ b/src/main/java/com/mcmoddev/mmdbot/updatenotifiers/game/MinecraftUpdateNotifier.java
@@ -24,6 +24,7 @@ public class MinecraftUpdateNotifier extends TimerTask {
     @Override
     public void run() {
         LOGGER.debug(NOTIFIER_MC, "Checking for new Minecraft versions...");
+        MinecraftVersionHelper.update();
         String latest = MinecraftVersionHelper.getLatest();
         String latestStable = MinecraftVersionHelper.getLatestStable();
         final long channelId = getConfig().getChannel("notifications.minecraft");

--- a/src/main/resources/default-config.toml
+++ b/src/main/resources/default-config.toml
@@ -123,6 +123,10 @@
     # These will be excluded from the error message when a command is sent from a non-allowed channel
     hidden_channels = []
 
+    # The snowflake IDs (or aliases) of roles exempted from the allowlist and blocklist checking
+    # This means that members with these roles may run any (enabled) command in any channel
+    exempt_roles = []
+
     # Configuration of the commands prefixes
     [commands.prefix]
         # The main commands prefix for bot commands

--- a/src/main/resources/default-config.toml
+++ b/src/main/resources/default-config.toml
@@ -119,6 +119,10 @@
 
 # Configuration for the bot commands
 [commands]
+    # The snowflake IDs (or aliases) of 'hidden' channels or categories
+    # These will be excluded from the error message when a command is sent from a non-allowed channel
+    hidden_channels = []
+
     # Configuration of the commands prefixes
     [commands.prefix]
         # The main commands prefix for bot commands

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -27,7 +27,7 @@
         </encoder>
     </appender>
     <!--Log levels include ERROR, WARN, INFO, DEBUG, TRACE-->
-    <root level="WARN">
+    <root level="DEBUG">
         <appender-ref ref="CONSOLE"/>
     </root>
 


### PR DESCRIPTION
Hello! <sup>I dream about the logic, I write down the code</sup>

This PR does the following:
* Fixes certain event logging calls using snowflake IDs directly, instead of using the `IMentionable`s and allowing the layout to convert them.
* Modifies the update notifiers to always check for versions and log to console, even if the notification channels are unset.
  * Also drops the logging level of the Forge notifier's 'no version' message to `DEBUG`.
* Improve the event notifications for role additions, role removals, and nickname changes. Now it uses more of the `RestAction` system, converting it all to a more neater layout.
  * The forced 2 seconds delay between the event and retrieving the audit log entry is now removed. As a safeguard, it is checked if the retrieved audit log entry's target and the event's target are the same; if not, a warning is logged to console and the editor is not attributed in the embed message.
* Adds a 'hidden' channels feature to commands. Hidden channels are hidden from the message sent when a command is run in a non-allowed channel.
* Add a list of channel-checking-exempt roles for commands. Users with these roles may run any (enabled) command in all channels, bypassing that channels' allowlist and/or blocklist. _(Disabled commands, both globally or in a guild, are still disabled and cannot be run)_
* Modifies the `MMDBot.VERSION` variable to not be null when run in an environment where the version is missing (e.g. there is no JAR manifest, such as during development), by using a fallback value of the string `"DEV "` + the date and time when the bot's class was loaded (i.e. when the bot was run).
* Changes the minimum logging level of logging messages to the bot program's console (as opposed to the channel console) to `DEBUG`.