### PR TITLE
More cleanup

### DIFF
--- a/src/main/java/com/mcmoddev/mmdbot/events/users/EventNicknameChanged.java
+++ b/src/main/java/com/mcmoddev/mmdbot/events/users/EventNicknameChanged.java
@@ -58,7 +58,7 @@ public final class EventNicknameChanged extends ListenerAdapter {
                     embed.addField("Old Nickname:", oldNick, true);
                     embed.addField("New Nickname:", newNick, true);
 
-                    LOGGER.info(EVENTS, "User {} changed nickname from {} to {}, by {}", target, oldNick, newNick, entry.getUser());
+                    LOGGER.info(EVENTS, "User {} changed nickname from `{}` to `{}`, by {}", target, oldNick, newNick, entry.getUser());
 
                     return channel.sendMessage(embed.build());
                 })

--- a/src/main/java/com/mcmoddev/mmdbot/events/users/EventUserJoined.java
+++ b/src/main/java/com/mcmoddev/mmdbot/events/users/EventUserJoined.java
@@ -56,11 +56,11 @@ public final class EventUserJoined extends ListenerAdapter {
             embed.setTitle("User Joined");
             embed.setThumbnail(user.getEffectiveAvatarUrl());
             embed.addField("User:", user.getAsTag(), true);
-            embed.addField("User ID:", user.getId(), true);
             //TODO Check if this works.
             if (!roles.isEmpty()) {
                 embed.addField("Roles:", roles.stream().map(IMentionable::getAsMention).collect(Collectors.joining()), true);
             }
+            embed.setFooter("User ID: " + user.getId());
             embed.setTimestamp(Instant.now());
 
             channel.sendMessage(embed.build()).queue();

--- a/src/main/java/com/mcmoddev/mmdbot/events/users/EventUserJoined.java
+++ b/src/main/java/com/mcmoddev/mmdbot/events/users/EventUserJoined.java
@@ -42,7 +42,7 @@ public final class EventUserJoined extends ListenerAdapter {
         if (getConfig().getGuildID() == guildId) {
             LOGGER.info(EVENTS, "User {} joined the guild", user);
             final List<Role> roles = Utils.getOldUserRoles(guild, user.getIdLong());
-            if (member != null) {
+            if (member != null && !roles.isEmpty()) {
                 LOGGER.info(EVENTS, "Giving old roles to user {}: {}", user, roles);
                 for (Role role : roles) {
                     try {
@@ -58,7 +58,9 @@ public final class EventUserJoined extends ListenerAdapter {
             embed.addField("User:", user.getAsTag(), true);
             embed.addField("User ID:", user.getId(), true);
             //TODO Check if this works.
-            embed.addField("Roles:", roles.stream().map(IMentionable::getAsMention).collect(Collectors.joining()), true);
+            if (!roles.isEmpty()) {
+                embed.addField("Roles:", roles.stream().map(IMentionable::getAsMention).collect(Collectors.joining()), true);
+            }
             embed.setTimestamp(Instant.now());
 
             channel.sendMessage(embed.build()).queue();

--- a/src/main/java/com/mcmoddev/mmdbot/events/users/EventUserLeft.java
+++ b/src/main/java/com/mcmoddev/mmdbot/events/users/EventUserLeft.java
@@ -54,7 +54,6 @@ public final class EventUserLeft extends ListenerAdapter {
             embed.setTitle("User Left");
             embed.setThumbnail(user.getEffectiveAvatarUrl());
             embed.addField("User:", user.getAsTag(), true);
-            embed.addField("User ID:", user.getId(), true);
             //TODO Check if this works.
             if (roles != null && !roles.isEmpty()) {
                 embed.addField("Roles:", roles.stream().map(IMentionable::getAsMention).collect(Collectors.joining()), true);
@@ -62,6 +61,7 @@ public final class EventUserLeft extends ListenerAdapter {
             } else if (roles == null) {
                 embed.addField("Roles:", "_Could not obtain user's roles._", true);
             }
+            embed.setFooter("User ID: " + user.getId());
             embed.setTimestamp(Instant.now());
 
             channel.sendMessage(embed.build()).queue();

--- a/src/main/java/com/mcmoddev/mmdbot/events/users/EventUserLeft.java
+++ b/src/main/java/com/mcmoddev/mmdbot/events/users/EventUserLeft.java
@@ -13,7 +13,6 @@ import net.dv8tion.jda.api.hooks.ListenerAdapter;
 
 import java.awt.Color;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -41,13 +40,13 @@ public final class EventUserLeft extends ListenerAdapter {
 
         if (getConfig().getGuildID() == guildId) {
             LOGGER.info(EVENTS, "User {} left the guild", user);
-            List<Role> roles = new ArrayList<>();
+            List<Role> roles = null;
             if (member != null) {
                 roles = member.getRoles();
+                Utils.writeUserRoles(user.getIdLong(), roles);
             } else {
                 LOGGER.warn(EVENTS, "Could not get roles of leaving user {}", user);
             }
-            Utils.writeUserRoles(user.getIdLong(), roles);
             if (member != null) {
                 Utils.writeUserJoinTimes(user.getId(), member.getTimeJoined().toInstant());
             }
@@ -57,10 +56,11 @@ public final class EventUserLeft extends ListenerAdapter {
             embed.addField("User:", user.getAsTag(), true);
             embed.addField("User ID:", user.getId(), true);
             //TODO Check if this works.
-            if (!roles.isEmpty()) {
+            if (roles != null && !roles.isEmpty()) {
                 embed.addField("Roles:", roles.stream().map(IMentionable::getAsMention).collect(Collectors.joining()), true);
-            } else {
-                embed.addField("Roles:", "Users roles currently unobtainable.", true);
+                LOGGER.info(EVENTS, "User {} had the following roles before leaving: {}", user, roles);
+            } else if (roles == null) {
+                embed.addField("Roles:", "_Could not obtain user's roles._", true);
             }
             embed.setTimestamp(Instant.now());
 

--- a/src/main/java/com/mcmoddev/mmdbot/logging/ConsoleChannelLayout.java
+++ b/src/main/java/com/mcmoddev/mmdbot/logging/ConsoleChannelLayout.java
@@ -49,6 +49,17 @@ public class ConsoleChannelLayout extends LayoutBase<ILoggingEvent> {
             .put(Level.TRACE, ":small_orange_diamond:")
             .build();
 
+    private boolean prependLevelName = true;
+
+    /**
+     * Sets whether to prepend the logging {@link Level} name to the output.
+     *
+     * @param prependLevelName Whether to prepend level names
+     */
+    public void setPrependLevelName(boolean prependLevelName) {
+        this.prependLevelName = prependLevelName;
+    }
+
     /**
      * Tries to convert the given object (or any contained objects within) to
      * {@linkplain IMentionable#getAsMention() string mentions}.
@@ -119,9 +130,13 @@ public class ConsoleChannelLayout extends LayoutBase<ILoggingEvent> {
     public String doLayout(final ILoggingEvent event) {
         final StringBuilder builder = new StringBuilder();
         builder
-                .append(LEVEL_TO_EMOTE.getOrDefault(event.getLevel(), UNKNOWN_EMOTE))
-                .append(" ")
-                .append(event.getLevel().toString())
+                .append(LEVEL_TO_EMOTE.getOrDefault(event.getLevel(), UNKNOWN_EMOTE));
+        if (prependLevelName) {
+            builder
+                    .append(" ")
+                    .append(event.getLevel().toString());
+        }
+        builder
                 .append(" [**")
                 .append(event.getLoggerName());
         if (event.getMarker() != null) {

--- a/src/main/java/com/mcmoddev/mmdbot/logging/ConsoleChannelLayout.java
+++ b/src/main/java/com/mcmoddev/mmdbot/logging/ConsoleChannelLayout.java
@@ -97,9 +97,9 @@ public class ConsoleChannelLayout extends LayoutBase<ILoggingEvent> {
                 name = ((Emote) obj).getName();
             }
             if (name != null) {
-                return String.format("%s:(%s|%s)", ((IMentionable) obj).getAsMention(), name, ((IMentionable) obj).getIdLong());
+                return String.format("%s (%s;`%s`)", ((IMentionable) obj).getAsMention(), name, ((IMentionable) obj).getIdLong());
             } else {
-                return String.format("%s:(%s)", ((IMentionable) obj).getAsMention(), ((IMentionable) obj).getIdLong());
+                return String.format("%s (`%s`)", ((IMentionable) obj).getAsMention(), ((IMentionable) obj).getIdLong());
             }
         } else if (obj instanceof Collection) {
             final Stream<Object> stream = ((Collection<?>) obj).stream()

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -33,7 +33,9 @@
 
     <appender name="CHANNEL" class="com.mcmoddev.mmdbot.logging.ConsoleChannelAppender">
         <allowMentions>false</allowMentions>
-        <layout class="com.mcmoddev.mmdbot.logging.ConsoleChannelLayout"/>
+        <layout class="com.mcmoddev.mmdbot.logging.ConsoleChannelLayout">
+            <prependLevelName>false</prependLevelName>
+        </layout>
     </appender>
 
     <!--Log levels include ERROR, WARN, INFO, DEBUG, TRACE-->


### PR DESCRIPTION
A few cleanup commits based on observations I had.
 - _Surround nickname in a code block when logging_
   This just makes the nickname more visually distinct when being logged to the console.
 - _Modify user joined event to only log role giving when old roles exist for the user_
   Cleans up the previous 2 messages per joining user to 1 under most circumstances.
 - _Modify messages of user left event_
   The unobtainable message in the event embed message will only show if the roles could not be retrieved, not if the user had no roles; and roles of leaving users will now be logged to console (to allow moderators to reference past roles of users if needed).
 - _Add snowflake ID (and name if available) when logging IMentionables_
   This is to allow identification of a user without needing to search up their user ID, because mentions alone make it hard to identify when the user has left the guild.
 - _Add option to disable prepending the level name to logging output_
   This is because the level emote already shows the level in a more visually distinct manner, that having the level name just duplicates info and wastes space. Also disables the level name prepending in the logback config. 
 - _Move user snowflake ID from join/leave embeds to footer_
   Makes the user join/leave embeds take up less horizontal space.