### PR TITLE
Add community channel create command

### DIFF
--- a/src/main/java/com/mcmoddev/mmdbot/MMDBot.java
+++ b/src/main/java/com/mcmoddev/mmdbot/MMDBot.java
@@ -19,6 +19,7 @@ import com.mcmoddev.mmdbot.commands.info.server.CmdMe;
 import com.mcmoddev.mmdbot.commands.info.server.CmdReadme;
 import com.mcmoddev.mmdbot.commands.info.server.CmdRoles;
 import com.mcmoddev.mmdbot.commands.info.server.CmdRules;
+import com.mcmoddev.mmdbot.commands.staff.CmdCommunityChannel;
 import com.mcmoddev.mmdbot.commands.staff.CmdMute;
 import com.mcmoddev.mmdbot.commands.staff.CmdUnmute;
 import com.mcmoddev.mmdbot.commands.staff.CmdUser;
@@ -40,7 +41,6 @@ import org.slf4j.LoggerFactory;
 import javax.security.auth.login.LoginException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
@@ -162,6 +162,7 @@ public final class MMDBot {
                     .addCommand(new CmdFabricVersion())
                     .addCommand(new CmdMute())
                     .addCommand(new CmdUnmute())
+                    .addCommand(new CmdCommunityChannel())
                     .setHelpWord("help")
                     .build();
 

--- a/src/main/java/com/mcmoddev/mmdbot/commands/staff/CmdCommunityChannel.java
+++ b/src/main/java/com/mcmoddev/mmdbot/commands/staff/CmdCommunityChannel.java
@@ -1,0 +1,108 @@
+package com.mcmoddev.mmdbot.commands.staff;
+
+import com.google.common.collect.Sets;
+import com.jagrosh.jdautilities.command.Command;
+import com.jagrosh.jdautilities.command.CommandEvent;
+import com.mcmoddev.mmdbot.MMDBot;
+import com.mcmoddev.mmdbot.core.Utils;
+import net.dv8tion.jda.api.MessageBuilder;
+import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.Emote;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.GuildChannel;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.TextChannel;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class CmdCommunityChannel extends Command {
+    private static final EnumSet<Permission> REQUIRED_PERMISSIONS = EnumSet.of(Permission.MANAGE_PERMISSIONS, Permission.MANAGE_CHANNEL);
+
+    public CmdCommunityChannel() {
+        super();
+        name = "create-community-channel";
+        aliases = new String[]{"community-channel", "comm-ch"};
+        help = "Creates a new community channel for the given user. Usage: !mmd-create-community-channel <user ID/mention> <channel name>";
+        hidden = true;
+        botPermissions = REQUIRED_PERMISSIONS.toArray(Permission[]::new);
+    }
+
+    @Override
+    protected void execute(final CommandEvent event) {
+        if (!Utils.checkCommand(this, event)) return;
+        final Guild guild = event.getGuild();
+        final TextChannel channel = event.getTextChannel();
+        final String[] args = event.getArgs().split(" ");
+        final Member author = event.getGuild().getMember(event.getAuthor());
+        if (author == null) return;
+
+        if (!author.hasPermission(REQUIRED_PERMISSIONS)) {
+            event.reply("You do not have permission to use this command.");
+            return;
+        }
+
+        final Member newOwner = Utils.getMemberFromString(args[0], event.getGuild());
+        if (newOwner == null) {
+            event.reply("Invalid user!");
+            return;
+        }
+        final String channelName = args[1];
+
+        final long categoryID = MMDBot.getConfig().getCommunityChannelCategory();
+        final net.dv8tion.jda.api.entities.Category category = guild.getCategoryById(categoryID);
+        if (categoryID == 0 || category == null) {
+            MMDBot.LOGGER.warn("Community channel category is incorrectly configured");
+            event.reply("Community channel category is incorrectly configured. Please contact the bot maintainers.");
+            return;
+        }
+
+        final EnumSet<Permission> ownerPermissions = MMDBot.getConfig().getCommunityChannelOwnerPermissions();
+        if (ownerPermissions.isEmpty()) {
+            MMDBot.LOGGER.warn("Community channel owner permissions is incorrectly configured");
+            event.reply("Channel owner permissions is incorrectly configured. Please contact the bot maintainers.");
+            return;
+        }
+
+        Set<Permission> diff = Sets.difference(ownerPermissions, event.getSelfMember().getPermissions());
+        if (!diff.isEmpty()) {
+            MMDBot.LOGGER.warn("Cannot assign permissions to channel owner due to insufficient permissions: {}", diff);
+            event.reply("Cannot assign certain permissions to channel owner due to insufficient permissions; continuing anyway...");
+            ownerPermissions.removeIf(diff::contains);
+        }
+
+        List<Emote> emote = new ArrayList<>(4);
+        emote.addAll(guild.getEmotesByName("mmd1", true));
+        emote.addAll(guild.getEmotesByName("mmd2", true));
+        emote.addAll(guild.getEmotesByName("mmd3", true));
+        emote.addAll(guild.getEmotesByName("mmd4", true));
+
+        // Flavor text: if the emotes are available, use them, else just use plain MMD
+        String emoteText = emote.size() == 4 ? emote.stream().map(Emote::getAsMention).collect(Collectors.joining()) : "";
+        final String flavorText = emoteText.isBlank() ? "MMD" : emoteText;
+
+        MMDBot.LOGGER.info("Creating new community channel for {}, named \"{}\" (command issued by {})", newOwner, channelName, author);
+        category.createTextChannel(channelName)
+            .flatMap(ch -> category.modifyTextChannelPositions()
+                .sortOrder(Comparator.comparing(GuildChannel::getName))
+                .map($ -> ch))
+            .flatMap(ch -> ch.putPermissionOverride(newOwner).setAllow(ownerPermissions).map($ -> ch))
+            .flatMap(ch -> ch.sendMessage(new MessageBuilder()
+                .appendFormat("Welcome %s to your new community channel, %s!%n", newOwner.getAsMention(), ch.getAsMention())
+                .append('\n')
+                .append("Please adhere to the Code of Conduct of the server")
+                .appendFormat(" (which can be visited from the <#%s> channel),", MMDBot.getConfig().getChannel("info.rules"))
+                .append(" specifically the Channel Policy section.").append('\n')
+                .append('\n')
+                .appendFormat("Thank you, and enjoy your new home here at %s!", flavorText)
+                .build())
+                .map($ -> ch)
+            )
+            .queue(c -> event.reply("Successfully created community channel at " + c.getAsMention() + "!"));
+
+    }
+}

--- a/src/main/java/com/mcmoddev/mmdbot/commands/staff/CmdCommunityChannel.java
+++ b/src/main/java/com/mcmoddev/mmdbot/commands/staff/CmdCommunityChannel.java
@@ -29,7 +29,7 @@ public class CmdCommunityChannel extends Command {
         aliases = new String[]{"community-channel", "comm-ch"};
         help = "Creates a new community channel for the given user. Usage: !mmd-create-community-channel <user ID/mention> <channel name>";
         hidden = true;
-        botPermissions = REQUIRED_PERMISSIONS.toArray(Permission[]::new);
+        botPermissions = REQUIRED_PERMISSIONS.toArray(new Permission[0]);
     }
 
     @Override
@@ -83,7 +83,7 @@ public class CmdCommunityChannel extends Command {
 
         // Flavor text: if the emotes are available, use them, else just use plain MMD
         String emoteText = emote.size() == 4 ? emote.stream().map(Emote::getAsMention).collect(Collectors.joining()) : "";
-        final String flavorText = emoteText.isBlank() ? "MMD" : emoteText;
+        final String flavorText = emoteText.isEmpty() ? "MMD" : emoteText;
 
         MMDBot.LOGGER.info("Creating new community channel for {}, named \"{}\" (command issued by {})", newOwner, channelName, author);
         category.createTextChannel(channelName)

--- a/src/main/java/com/mcmoddev/mmdbot/core/BotConfig.java
+++ b/src/main/java/com/mcmoddev/mmdbot/core/BotConfig.java
@@ -336,7 +336,7 @@ public final class BotConfig {
             return permissions;
         }
         MMDBot.LOGGER.warn("Unknown format of \"community_channels.owner_permissions\", resetting to blank list");
-        config.set("community_channels.owner_permissions", List.of());
+        config.set("community_channels.owner_permissions", Collections.emptyList());
         return EnumSet.noneOf(Permission.class);
     }
 

--- a/src/main/resources/default-config.toml
+++ b/src/main/resources/default-config.toml
@@ -117,6 +117,18 @@
         # Threshold where the request is removed and the user is informed of its removal
         removal = 5
 
+# Configuration of community channels
+# This is used for the community channel creation command
+[community_channels]
+    # The snowflake ID (or alias) of the channel category where new community channels are created under
+    category = ""
+
+    # The default permissions of channel owners in their new community channels
+    # This can be either bitfield, or a list of strings of the names of permissions (see the Permission enum)
+    # Note: the bot can only assign permissions to channel owners if the bot has those permissions
+    # Example: ["Manage Messages", "MANAGE_PERMISSIONS"]
+    owner_permissions = []
+
 # Configuration for the bot commands
 [commands]
     # The snowflake IDs (or aliases) of 'hidden' channels or categories


### PR DESCRIPTION
Add command to create new community channels, as [requested by ProxyNeko (in private bot-helpers channel)](https://discord.com/channels/176780432371744769/797440750971387925/806618960144760874).

Usage: `!mmd-create-community-channel <user ID/mention> <channel name>`
The invoking user must have the `Manage Channels` (channel creation and manipulation) and `Manage Roles` (permission override creation for channel owner) permissions.

Two new configuration entries: `community_channels.category` and `community_channels.owner_permissions`.
> #### `community_channels.category`
> A snowflake ID (or alias) of the category where new community channels are created under

> #### `community_channels.owner_permissions`
> A bitfield (a number) or a list of strings defining the new permissions overrides of the channel owner in the new channel.
> Example: `["Manage Channels", "MANAGE_PERMISSIONS", "Manage Messages"]`
> (the first is the friendly name, the second is the internal name as defined in the [`Permission` enum](https://ci.dv8tion.net/job/JDA/javadoc/net/dv8tion/jda/api/Permission.html))

Does the following in order:
 - Creates a channel under the configured community channel category with the given channel name.
 - Sorts the channels under the configured community channel category in alphabetical/lexicographical order.
   _Note: This sorts **all** of the channels in the category._
 - Sets the permissions override of the given channel order to the configured permissions.
 - Sends a welcome message in the new channel, pinging the new channel owner.
<details>
<summary>Image of the welcome message in the newly created channel</summary>
<img src="https://user-images.githubusercontent.com/21304337/109212332-5b22ec00-77ea-11eb-8a6f-80ac0eb83d6e.png">
</details>
<details>
<summary>Image of the command being issued by a moderator to create a new channel</summary>
<img src="https://user-images.githubusercontent.com/21304337/109212976-0c298680-77eb-11eb-8e42-eb51819444bb.png">
</details>

If any unknown permission in present in the `community_channels.owner_permissions` config setting, it is logged to the console. If the setting is misconfigured with a object type different from expected (such as a string), the config setting is reset and a message is logged to console.