### PR TITLE
Add request deletion on user leaving feature, and others

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,10 @@ repositories {
     maven {
         url 'https://jitpack.io'
     }
+    maven {
+        name 'm2-dv8tion'
+        url 'https://m2.dv8tion.net/releases'
+    }
 }
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 bot_version=3.1.2
 jdautils_version=3.0.5
-jda_version=4.2.0_229
+jda_version=4.2.1_261
 guava_version=29.0-jre
 gson_version=2.8.6
 logback_classic_version=1.2.3

--- a/src/main/java/com/mcmoddev/mmdbot/MMDBot.java
+++ b/src/main/java/com/mcmoddev/mmdbot/MMDBot.java
@@ -12,6 +12,7 @@ import com.mcmoddev.mmdbot.commands.info.CmdPaste;
 import com.mcmoddev.mmdbot.commands.info.CmdSearch;
 import com.mcmoddev.mmdbot.commands.info.CmdXy;
 import com.mcmoddev.mmdbot.commands.info.fun.CmdCatFacts;
+import com.mcmoddev.mmdbot.commands.info.fun.CmdGreatMoves;
 import com.mcmoddev.mmdbot.commands.info.server.CmdGuild;
 import com.mcmoddev.mmdbot.commands.info.server.CmdMe;
 import com.mcmoddev.mmdbot.commands.info.server.CmdReadme;
@@ -163,6 +164,7 @@ public final class MMDBot {
                 .addCommand(new CmdMute())
                 .addCommand(new CmdUnmute())
                 .addCommand(new CmdCommunityChannel())
+                .addCommand(new CmdGreatMoves())
                 .setHelpWord("help")
                 .build();
 

--- a/src/main/java/com/mcmoddev/mmdbot/commands/info/fun/CmdGreatMoves.java
+++ b/src/main/java/com/mcmoddev/mmdbot/commands/info/fun/CmdGreatMoves.java
@@ -1,0 +1,20 @@
+package com.mcmoddev.mmdbot.commands.info.fun;
+
+import com.jagrosh.jdautilities.command.Command;
+import com.jagrosh.jdautilities.command.CommandEvent;
+
+public class CmdGreatMoves extends Command {
+    public static final String URL = "https://soundcloud.com/aldenchambers/great-moves-keep-it-up";
+
+    public CmdGreatMoves() {
+        name = "greatmoves";
+        aliases = new String[]{"great-moves"};
+        help = "Posts an encouraging message in chat.";
+        guildOnly = false;
+    }
+
+    @Override
+    protected void execute(final CommandEvent event) {
+        event.reply("Great Moves! Keep it Up! Proud of ya! Papa bless!" + '\n' + URL);
+    }
+}

--- a/src/main/java/com/mcmoddev/mmdbot/commands/info/server/CmdGuild.java
+++ b/src/main/java/com/mcmoddev/mmdbot/commands/info/server/CmdGuild.java
@@ -43,11 +43,11 @@ public final class CmdGuild extends Command {
         embed.setColor(Color.GREEN);
         embed.setThumbnail(guild.getIconUrl());
         embed.addField("Guilds name:", guild.getName(), true);
-        embed.addField("Member count:", Integer.toString(guild.getMembers().size()), true);
-        embed.addField("Emote count:", Integer.toString(guild.getEmotes().size()), true);
-        embed.addField("Category count:", Integer.toString(guild.getCategories().size()), true);
+        embed.addField("Member count:", Integer.toString(guild.getMemberCount()), true);
+        embed.addField("Emote count:", Long.toString(guild.getEmoteCache().size()), true);
+        embed.addField("Category count:", Long.toString(guild.getCategoryCache().size()), true);
         embed.addField("Channel count:", Integer.toString(guild.getChannels().size()), true);
-        embed.addField("Role count:", Integer.toString(guild.getRoles().size()), true);
+        embed.addField("Role count:", Long.toString(guild.getRoleCache().size()), true);
         embed.addField("Date created:", new SimpleDateFormat("yyyy/MM/dd HH:mm", Locale.ENGLISH).format(dateGuildCreated.toEpochMilli()), true);
         embed.addField("Guilds age:", Utils.getTimeDifference(Utils.getLocalTime(dateGuildCreated), LocalDateTime.now()), true);
         embed.setTimestamp(Instant.now());

--- a/src/main/java/com/mcmoddev/mmdbot/core/BotConfig.java
+++ b/src/main/java/com/mcmoddev/mmdbot/core/BotConfig.java
@@ -254,6 +254,21 @@ public final class BotConfig {
     }
 
     /**
+     * Returns the amount of time in hours since a request was created for it to be deleted upon the user leaving the
+     * server.
+     * <p>
+     * For example, a value of {@code 5} means all requests made by a user who leaves the server that is less than 5
+     * hours old will be deleted.
+     * <p>
+     * A value of {@code 0} disables this leave deletion functionality.
+     *
+     * @return The time in hours since request creation by a leaving user to be deleted
+     */
+    public int getRequestLeaveDeletionTime() {
+        return config.getIntOrElse("requests.leave_deletion", 0);
+    }
+
+    /**
      * Returns the list of snowflake IDs of the reaction emotes for bad requests.
      *
      * @return The list of snowflake IDs of bad request reaction emotes

--- a/src/main/java/com/mcmoddev/mmdbot/core/BotConfig.java
+++ b/src/main/java/com/mcmoddev/mmdbot/core/BotConfig.java
@@ -269,6 +269,20 @@ public final class BotConfig {
     }
 
     /**
+     * Returns the amount of time in days where a request is actionable using the requests warning and removal system.
+     * <p>
+     * A request that has existed for longer that this duration (a "stale request") will not cause the warning or
+     * removal threshold to trip when reacted to by users.
+     * <p>
+     * A value of {@code 0} disables this freshness functionality, and allows any request to be actionable.
+     *
+     * @return The time in days for a request to be actionable by the warning system
+     */
+    public int getRequestFreshnessDuration() {
+        return config.getIntOrElse("requests.freshness_duration", 0);
+    }
+
+    /**
      * Returns the list of snowflake IDs of the reaction emotes for bad requests.
      *
      * @return The list of snowflake IDs of bad request reaction emotes

--- a/src/main/java/com/mcmoddev/mmdbot/events/EventReactionAdded.java
+++ b/src/main/java/com/mcmoddev/mmdbot/events/EventReactionAdded.java
@@ -11,6 +11,7 @@ import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.dv8tion.jda.api.requests.RestAction;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -69,7 +70,9 @@ public final class EventReactionAdded extends ListenerAdapter {
 
                 final TextChannel logChannel = guild.getTextChannelById(getConfig().getChannel("events.requests_deletion"));
                 if (logChannel != null) {
-                    logChannel.sendMessage(String.format("Auto-deleted request from %s: %s", messageAuthor.getId(), message.getContentRaw())).queue();
+                    logChannel.sendMessage(String.format("Auto-deleted request from %s due to reaching deletion threshold: %n%s", messageAuthor.getId(), message.getContentRaw()))
+                        .allowedMentions(Collections.emptySet())
+                        .queue();
                 }
 
                 channel.deleteMessageById(event.getMessageId())

--- a/src/main/java/com/mcmoddev/mmdbot/events/EventReactionAdded.java
+++ b/src/main/java/com/mcmoddev/mmdbot/events/EventReactionAdded.java
@@ -11,6 +11,7 @@ import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.dv8tion.jda.api.requests.RestAction;
 
+import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -46,6 +47,15 @@ public final class EventReactionAdded extends ListenerAdapter {
         if (removalThreshold == 0 || warningThreshold == 0) return;
 
         if (getConfig().getGuildID() == guildId && getConfig().getChannel("requests.main") == channel.getIdLong()) {
+
+            int freshnessDuration = getConfig().getRequestFreshnessDuration();
+            if (freshnessDuration > 0) {
+                OffsetDateTime creationTime = message.getTimeCreated();
+                OffsetDateTime now = OffsetDateTime.now();
+                if (now.minusDays(freshnessDuration).isAfter(creationTime)) {
+                    return; // Do nothing if the request has gone past the freshness duration
+                }
+            }
 
             final List<Long> badReactionsList = getConfig().getBadRequestsReactions();
             final List<Long> goodReactionsList = getConfig().getGoodRequestsReactions();

--- a/src/main/java/com/mcmoddev/mmdbot/events/EventReactionAdded.java
+++ b/src/main/java/com/mcmoddev/mmdbot/events/EventReactionAdded.java
@@ -80,7 +80,7 @@ public final class EventReactionAdded extends ListenerAdapter {
 
                 final TextChannel logChannel = guild.getTextChannelById(getConfig().getChannel("events.requests_deletion"));
                 if (logChannel != null) {
-                    logChannel.sendMessage(String.format("Auto-deleted request from %s due to reaching deletion threshold: %n%s", messageAuthor.getId(), message.getContentRaw()))
+                    logChannel.sendMessage(String.format("Auto-deleted request from %s (%s;%s) due to reaching deletion threshold: %n%s", messageAuthor.getAsMention(), messageAuthor.getAsTag(), messageAuthor.getId(), message.getContentRaw()))
                         .allowedMentions(Collections.emptySet())
                         .queue();
                 }

--- a/src/main/java/com/mcmoddev/mmdbot/events/users/EventRoleAdded.java
+++ b/src/main/java/com/mcmoddev/mmdbot/events/users/EventRoleAdded.java
@@ -1,5 +1,7 @@
 package com.mcmoddev.mmdbot.events.users;
 
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
 import com.mcmoddev.mmdbot.core.Utils;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.audit.ActionType;
@@ -13,6 +15,7 @@ import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import java.awt.Color;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -26,6 +29,15 @@ import static com.mcmoddev.mmdbot.logging.MMDMarkers.EVENTS;
 public final class EventRoleAdded extends ListenerAdapter {
 
     /**
+     * Multimap of users to roles which will be ignored when encountered for the first time.
+     * <p>
+     * Once a user to role entry has been encountered, it is removed from the map.
+     * <p>
+     * Used to ignore roles added back by {@link EventUserJoined role persistance}.
+     */
+    public static final Multimap<User, Role> IGNORE_ONCE = HashMultimap.create();
+
+    /**
      *
      */
     @Override
@@ -37,6 +49,25 @@ public final class EventRoleAdded extends ListenerAdapter {
         if (getConfig().getGuildID() != guild.getIdLong())
             return; // Make sure that we don't post if it's not related to 'our' guild
 
+        final List<Role> previousRoles = new ArrayList<>(event.getMember().getRoles());
+        final List<Role> addedRoles = new ArrayList<>(event.getRoles());
+        previousRoles.removeAll(addedRoles); // Just if the member has already been updated
+
+        if (IGNORE_ONCE.containsKey(target)) { // Check for ignored roles
+            Iterator<Role> ignoredRoles = IGNORE_ONCE.get(target).iterator();
+            while (ignoredRoles.hasNext()) {
+                Role ignored = ignoredRoles.next();
+                if (addedRoles.contains(ignored)) { // Remove ignored roles from event listing and ignore map
+                    LOGGER.info(EVENTS, "Role {} for {} was in role ignore map, removing from map and ignoring", ignored, target);
+                    addedRoles.remove(ignored);
+                    ignoredRoles.remove();
+                }
+            }
+            if (addedRoles.isEmpty()) { // If all the roles were ignored, exit out.
+                return;
+            }
+        }
+
         Utils.getChannelIfPresent(channelID, channel ->
             guild.retrieveAuditLogs()
                 .type(ActionType.MEMBER_ROLE_UPDATE)
@@ -44,10 +75,6 @@ public final class EventRoleAdded extends ListenerAdapter {
                 .cache(false)
                 .map(list -> list.get(0))
                 .flatMap(entry -> {
-                    final List<Role> previousRoles = new ArrayList<>(event.getMember().getRoles());
-                    final List<Role> addedRoles = new ArrayList<>(event.getRoles());
-                    previousRoles.removeAll(addedRoles); // Just if the member has already been updated
-
                     final EmbedBuilder embed = new EmbedBuilder();
 
                     embed.setColor(Color.YELLOW);

--- a/src/main/java/com/mcmoddev/mmdbot/events/users/EventUserJoined.java
+++ b/src/main/java/com/mcmoddev/mmdbot/events/users/EventUserJoined.java
@@ -44,6 +44,7 @@ public final class EventUserJoined extends ListenerAdapter {
             final List<Role> roles = Utils.getOldUserRoles(guild, user.getIdLong());
             if (member != null && !roles.isEmpty()) {
                 LOGGER.info(EVENTS, "Giving old roles to user {}: {}", user, roles);
+                EventRoleAdded.IGNORE_ONCE.putAll(user, roles);
                 for (Role role : roles) {
                     try {
                         guild.addRoleToMember(member, role).queue();

--- a/src/main/java/com/mcmoddev/mmdbot/events/users/EventUserLeft.java
+++ b/src/main/java/com/mcmoddev/mmdbot/events/users/EventUserLeft.java
@@ -86,7 +86,7 @@ public final class EventUserLeft extends ListenerAdapter {
 
                         final TextChannel logChannel = guild.getTextChannelById(getConfig().getChannel("events.requests_deletion"));
                         if (logChannel != null) {
-                            logChannel.sendMessage(String.format("Auto-deleted request from %s due to leaving server: %n%s", leavingUser.getId(), message.getContentRaw()))
+                            logChannel.sendMessage(String.format("Auto-deleted request from %s (%s;`%s`) due to leaving server: %n%s", leavingUser.getAsMention(), leavingUser.getAsTag(), leavingUser.getId(), message.getContentRaw()))
                                 .allowedMentions(Collections.emptySet())
                                 .queue();
                         }

--- a/src/main/java/com/mcmoddev/mmdbot/events/users/EventUserLeft.java
+++ b/src/main/java/com/mcmoddev/mmdbot/events/users/EventUserLeft.java
@@ -74,7 +74,7 @@ public final class EventUserLeft extends ListenerAdapter {
     }
 
     private void deleteRecentRequests(Guild guild, User leavingUser) {
-        TextChannel requestsChannel = guild.getTextChannelById(getConfig().getChannel("channels.requests.main"));
+        TextChannel requestsChannel = guild.getTextChannelById(getConfig().getChannel("requests.main"));
         int deletionTime = getConfig().getRequestLeaveDeletionTime();
         if (requestsChannel != null && deletionTime > 0) {
             OffsetDateTime now = OffsetDateTime.now().minusHours(deletionTime);

--- a/src/main/java/com/mcmoddev/mmdbot/events/users/EventUserLeft.java
+++ b/src/main/java/com/mcmoddev/mmdbot/events/users/EventUserLeft.java
@@ -13,12 +13,15 @@ import net.dv8tion.jda.api.hooks.ListenerAdapter;
 
 import java.awt.Color;
 import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import static com.mcmoddev.mmdbot.MMDBot.LOGGER;
 import static com.mcmoddev.mmdbot.MMDBot.getConfig;
 import static com.mcmoddev.mmdbot.logging.MMDMarkers.EVENTS;
+import static com.mcmoddev.mmdbot.logging.MMDMarkers.REQUESTS;
 
 /**
  *
@@ -50,11 +53,13 @@ public final class EventUserLeft extends ListenerAdapter {
             if (member != null) {
                 Utils.writeUserJoinTimes(user.getId(), member.getTimeJoined().toInstant());
             }
+
+            deleteRecentRequests(guild, user);
+
             embed.setColor(Color.RED);
             embed.setTitle("User Left");
             embed.setThumbnail(user.getEffectiveAvatarUrl());
             embed.addField("User:", user.getAsTag(), true);
-            //TODO Check if this works.
             if (roles != null && !roles.isEmpty()) {
                 embed.addField("Roles:", roles.stream().map(IMentionable::getAsMention).collect(Collectors.joining()), true);
                 LOGGER.info(EVENTS, "User {} had the following roles before leaving: {}", user, roles);
@@ -65,6 +70,31 @@ public final class EventUserLeft extends ListenerAdapter {
             embed.setTimestamp(Instant.now());
 
             channel.sendMessage(embed.build()).queue();
+        }
+    }
+
+    private void deleteRecentRequests(Guild guild, User leavingUser) {
+        TextChannel requestsChannel = guild.getTextChannelById(getConfig().getChannel("channels.requests.main"));
+        int deletionTime = getConfig().getRequestLeaveDeletionTime();
+        if (requestsChannel != null && deletionTime > 0) {
+            OffsetDateTime now = OffsetDateTime.now().minusHours(deletionTime);
+            requestsChannel.getIterableHistory()
+                .takeWhileAsync(message -> message.getTimeCreated().isAfter(now) && message.getAuthor().equals(leavingUser))
+                .thenAccept(messages ->
+                    messages.forEach(message -> {
+                        LOGGER.info(REQUESTS, "Removed request from {} (current leave deletion of {} hour(s), sent {}) because they left the server", leavingUser, message.getTimeCreated(), deletionTime);
+
+                        final TextChannel logChannel = guild.getTextChannelById(getConfig().getChannel("events.requests_deletion"));
+                        if (logChannel != null) {
+                            logChannel.sendMessage(String.format("Auto-deleted request from %s due to leaving server: %n%s", leavingUser.getId(), message.getContentRaw()))
+                                .allowedMentions(Collections.emptySet())
+                                .queue();
+                        }
+
+                        message.delete()
+                            .reason(String.format("User left, message created at %s, within leave deletion threshold of %s hour(s)", message.getTimeCreated(), deletionTime))
+                            .queue();
+                    }));
         }
     }
 }

--- a/src/main/java/com/mcmoddev/mmdbot/updatenotifiers/forge/ForgeUpdateNotifier.java
+++ b/src/main/java/com/mcmoddev/mmdbot/updatenotifiers/forge/ForgeUpdateNotifier.java
@@ -13,7 +13,7 @@ import static com.mcmoddev.mmdbot.logging.MMDMarkers.NOTIFIER_FORGE;
 
 public class ForgeUpdateNotifier extends TimerTask {
 
-    private static final String CHANGELOG_URL_TEMPLATE = "https://files.minecraftforge.net/maven/net/minecraftforge/forge/%1$s-%2$s/forge-%1$s-%2$s-changelog.txt";
+    private static final String CHANGELOG_URL_TEMPLATE = "https://maven.minecraftforge.net/net/minecraftforge/forge/%1$s-%2$s/forge-%1$s-%2$s-changelog.txt";
     String mcVersion;
     ForgeVersion lastForgeVersions;
 

--- a/src/main/java/com/mcmoddev/mmdbot/updatenotifiers/forge/ForgeVersionHelper.java
+++ b/src/main/java/com/mcmoddev/mmdbot/updatenotifiers/forge/ForgeVersionHelper.java
@@ -13,7 +13,7 @@ import java.util.regex.Pattern;
 
 public class ForgeVersionHelper {
 
-    private static final String VERSION_URL = "https://files.minecraftforge.net/maven/net/minecraftforge/forge/promotions_slim.json";
+    private static final String VERSION_URL = "https://files.minecraftforge.net/net/minecraftforge/forge/promotions_slim.json";
     private static final Pattern VERSION_REGEX = Pattern.compile("(.+?)-(.+)");
 
     private static final Gson gson = new Gson();
@@ -54,9 +54,8 @@ public class ForgeVersionHelper {
 
         ForgePromoData data = gson.fromJson(reader, ForgePromoData.class);
 
-        // Remove broken entries from the API
-        data.promos.remove("1.7.10-latest-1.7.10");
-        data.promos.remove("latest-1.7.10");
+        // Remove this specific entry (differs from others with having the `_pre4` version)
+        data.promos.remove("1.7.10_pre4-latest");
 
         // Collect version data
         Map<String, ForgeVersion> versions = new HashMap<>();

--- a/src/main/resources/default-config.toml
+++ b/src/main/resources/default-config.toml
@@ -94,6 +94,12 @@
 
 # Configuration for the requests bad reaction threshold
 [requests]
+    # Time in hours since request creation for a request of a user who left the server to be deleted
+    # For example, a value of 3 hours would mean any requests less than 3 hours old by a user who just
+    # left the server will be deleted
+    # A value of 0 will leave this functionality disabled
+    leave_deletion = 0
+
     # Configuration of the reaction emotes
     [requests.emotes]
         # The snowflake IDs of the reaction emotes for bad requests

--- a/src/main/resources/default-config.toml
+++ b/src/main/resources/default-config.toml
@@ -100,6 +100,11 @@
     # A value of 0 will leave this functionality disabled
     leave_deletion = 0
 
+    # Time in days for a request to be actionable through the request bad reactions systems
+    # Any request past this freshness duration (stale requests) will not trigger the warning or deletion threshold
+    # A value of 0 will leave this functionality disabled
+    freshness_duration = 0
+
     # Configuration of the reaction emotes
     [requests.emotes]
         # The snowflake IDs of the reaction emotes for bad requests

--- a/src/test/java/com/mcmoddev/mmdbot/helpers/forge/ForgeVersionHelperTest.java
+++ b/src/test/java/com/mcmoddev/mmdbot/helpers/forge/ForgeVersionHelperTest.java
@@ -27,7 +27,7 @@ class ForgeVersionHelperTest {
             assertTrue(result.size() > 0);
             assertTrue(result.containsKey("1.7.10"));
             assertEquals(result.get("1.7.10").getLatest(), "10.13.4.1614");
-            assertEquals(result.get("1.7.10").getRecommended(), "10.13.4.1558");
+            assertEquals(result.get("1.7.10").getRecommended(), "10.13.4.1614");
         } catch(Exception e) {
             fail("Exception thrown", e);
         }


### PR DESCRIPTION
## Changes Summary
- **Add request deletion of users who leave the server**
  <sup>subcommit: _Remove "channels." prefix in #getChannel call in leaving user request deletion_</sup>
  Adds the feature of deleting recent requests made by users who leave the server. A new config option is added, `leave_deletion`, which is the maximum time in hours for a request to be deleted. 
  A request is deleted if the time between the request message creation and the time the user left is less than the leave deletion threshold. A request deleted this way will be logged in the bot console and in the deleted requests channel.

- **Add freshness duration setting to request removal system**
  Adds a new config option, `freshness_duration`, which is the time in days for a request to be considered 'fresh'. Only reactions with the request emotes to 'fresh' requests will cause MMDBot to take action; a reaction to a request that has existed for longer than this duration (a 'stale' request) will not cause a warning or deletion when reacted to by users.
  This is a safeguard feature to prevent brigading users from abusing MMDBot to spam DM users by reacting to very old request messages.

- **Ignore roles added by role persist in events logging**
  Roles added by MMDBot as part of the role persistance feature will not cause an event informational embed to be created (but it will still be logged in the bot console).

- **Re-add great moves command (from v2.0)**
  "Great Moves!" Readds the [`!greatmoves` command from v2.0][greatmoves] of the bot. 

- **Update JDA version to 4.2.1_261, use new JDA maven**
  Updates the JDA version to the latest as of time of committing: 4.2.1_261. Also adds the new JDA maven, as they moved off of JCenter due to its sunsetting.
  _Note:_ The JCenter repository still remains in the buildscript because JDA-Utilities is still hosted on there. We may need to investigate rehosting a copy somewhere else, if it isn't moved to a new repository by their maintainers.

### Misc. changes
- **Adjust request deletion log message to include user tag and ID**
  Adds the user tag and ID to the request deletion log message, to aid in finding out who the deleted request belonged to.
- **Amend ForgeVersionHelper to new URL and broken entry**
  As Forge recently shuffled around their public-facing stuff due to server issues, their maven is now hosted at the `maven.minecraftforge.net` subdomain (instead of `files.minecraftforge.net/maven`. Additionally, the location for `promotions_slim.json` was slightly adjusted, removing the `maven/` part of the URL.
- **Adjust how the guild command retrieves info**
  Uses [`Guild#getMemberCount`][getMemberCount] and moves to directly checking the size of the snowflake caches for emotes, categories, and roles (to avoid creating a new list object for each query).
- **Always prevent pings from logged request deletion**
  A safeguard feature, to prevent pings from mentions in logged requests.

[greatmoves]: https://github.com/MinecraftModDevelopment/MMDBot/blob/2.0/src/main/java/com/mcmoddev/bot/command/CommandGreatMoves.java
[getMemberCount]: https://ci.dv8tion.net/job/JDA/javadoc/net/dv8tion/jda/api/entities/Guild.html#getMemberCount()