### PR TITLE
Add staff signoff to request deletion

### DIFF
--- a/src/main/java/com/mcmoddev/mmdbot/core/Utils.java
+++ b/src/main/java/com/mcmoddev/mmdbot/core/Utils.java
@@ -150,6 +150,22 @@ public final class Utils {
     }
 
     /**
+     * Gets reactions matching a predicate
+     *
+     * @param message   The message we are getting the matching reactions from.
+     * @param predicate The predicate
+     * @return The matching reactions.
+     */
+    public static List<MessageReaction> getMatchingReactions(final Message message, final LongPredicate predicate) {
+        return message
+            .getReactions()
+            .stream()
+            .filter(messageReaction -> messageReaction.getReactionEmote().isEmote())
+            .filter(messageReaction -> predicate.test(messageReaction.getReactionEmote().getIdLong()))
+            .collect(Collectors.toList());
+    }
+
+    /**
      * Gets number of matching reactions.
      *
      * @param message   The message we are getting the number of matching reactions from.


### PR DESCRIPTION
Require a member of staff with the Kick permissions, so moderator or admin, to mark a request as bad before it's deleted.