### PR TITLE
Add a WIP quote manager and three commands to manage them.

### DIFF
--- a/src/main/java/com/mcmoddev/mmdbot/modules/commands/CommandModule.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/commands/CommandModule.java
@@ -11,6 +11,9 @@ import com.mcmoddev.mmdbot.modules.commands.general.info.CmdPaste;
 import com.mcmoddev.mmdbot.modules.commands.general.info.CmdSearch;
 import com.mcmoddev.mmdbot.modules.commands.general.info.CmdXy;
 import com.mcmoddev.mmdbot.modules.commands.server.moderation.CmdUser;
+import com.mcmoddev.mmdbot.modules.commands.server.quotes.CmdAddQuote;
+import com.mcmoddev.mmdbot.modules.commands.server.quotes.CmdGetQuote;
+import com.mcmoddev.mmdbot.modules.commands.server.quotes.CmdRemoveQuote;
 import com.mcmoddev.mmdbot.modules.commands.server.tricks.CmdAddTrick;
 import com.mcmoddev.mmdbot.MMDBot;
 import com.mcmoddev.mmdbot.modules.commands.bot.info.CmdAbout;
@@ -101,6 +104,9 @@ public class CommandModule {
             .addCommand(new CmdRemoveTrick())
             .addCommands(Tricks.createTrickCommands().toArray(new Command[0]))
             .addCommand(new CmdShutdown())
+            .addCommand(new CmdAddQuote())
+            .addCommand(new CmdGetQuote())
+            .addCommand(new CmdRemoveQuote())
             .setHelpWord("help")
             .build();
 

--- a/src/main/java/com/mcmoddev/mmdbot/modules/commands/server/quotes/CmdAddQuote.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/commands/server/quotes/CmdAddQuote.java
@@ -1,0 +1,111 @@
+package com.mcmoddev.mmdbot.modules.commands.server.quotes;
+
+import com.jagrosh.jdautilities.command.Command;
+import com.jagrosh.jdautilities.command.CommandEvent;
+import com.mcmoddev.mmdbot.core.Utils;
+import com.mcmoddev.mmdbot.utilities.quotes.Quote;
+import com.mcmoddev.mmdbot.utilities.quotes.QuoteList;
+import com.mcmoddev.mmdbot.utilities.quotes.StringQuote;
+import com.mcmoddev.mmdbot.utilities.quotes.UserReference;
+import net.dv8tion.jda.api.entities.TextChannel;
+
+/**
+ * Add a quote to the list.
+ *
+ * Possible forms:
+ *  !addquote "I said something funny" - @Curle
+ *  !addquote "I said something funny" - 462617385157787648
+ *  !addquote "I said something funny"
+ *  !addquote "I said something funny - The best bot developer
+ *
+ * Can be used by anyone.
+ *
+ * TODO: Prepare for more Quote implementations.
+ *
+ * @author Curle
+ */
+public final class CmdAddQuote extends Command {
+
+    /**
+     * Create the command.
+     * Sets all the usual flags.
+     */
+    public CmdAddQuote() {
+        super();
+        name = "addquote";
+        aliases = new String[] { "add-quote", "quoteadd", "quote-add" };
+        help = "Adds a new Quote to the list.\nAdd a quote like so: !addquote \"I said something funny - author\"!";
+    }
+
+    @Override
+    protected void execute(final CommandEvent event) {
+        if (!Utils.checkCommand(this, event))
+            return;
+
+        final TextChannel channel = event.getTextChannel();
+        String argsFull = event.getArgs();
+
+        String[] args = argsFull.split("-");
+        // args = [ "text", <@ID> ]
+
+        // Verify that there were any arguments
+        if (!(args.length > 0)) {
+            channel.sendMessage("Invalid arguments. See the help for this command.").queue();
+            return;
+        }
+
+        // Verify that there's a message being quoted.
+        if (!(args[0].charAt(0) == '\"')) {
+            channel.sendMessage("Invalid arguments. See the help for this command.").queue();
+            return;
+        }
+
+        // Remove the start and end quote.
+        args[0] = args[0].trim();
+        String quote = args[0].substring(1, args[0].length() - 1);
+
+        Quote finishedQuote;
+        // Fetch the user who created the quote
+        UserReference author = new UserReference(event.getAuthor().getIdLong());
+
+        // Check if there's any attribution
+        if (args.length == 1) {
+            // Anonymous quote.
+            UserReference quotee = new UserReference();
+
+            finishedQuote = new StringQuote(quotee, quote, author);
+        } else {
+            // args.length == 2 by logical deduction.
+
+            String quotee = args[1].trim();
+
+            final int mentionUsernameHeader = 3;
+            final int mentionStandardHeader = 2;
+
+            // Check if this is a mention
+            if (quotee.charAt(0) == '<' && quotee.charAt(1) == '@')
+                // Strip the tags from it
+                quotee = quotee.substring(quotee.charAt(2) == '!' ? mentionUsernameHeader : mentionStandardHeader,
+                    quotee.length() - 1);
+
+            // Check if there's a user ID here
+            try {
+                long id = Long.parseLong(quotee);
+                UserReference quoteeUser = new UserReference(id);
+                finishedQuote = new StringQuote(quoteeUser, quote, author);
+            } catch (NumberFormatException exception) {
+                // No user ID. Must be a string assignment.
+                UserReference quoteeUser = new UserReference(quotee);
+                finishedQuote = new StringQuote(quoteeUser, quote, author);
+            }
+        }
+
+        int quoteID = QuoteList.getQuoteSlot();
+        finishedQuote.setID(quoteID);
+
+        // All execution leads to here, where finishedQuote is valid.
+        QuoteList.addQuote(finishedQuote);
+
+        channel.sendMessage("Added quote " + quoteID + "!").queue();
+    }
+}

--- a/src/main/java/com/mcmoddev/mmdbot/modules/commands/server/quotes/CmdGetQuote.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/commands/server/quotes/CmdGetQuote.java
@@ -1,0 +1,91 @@
+package com.mcmoddev.mmdbot.modules.commands.server.quotes;
+
+import com.jagrosh.jdautilities.command.Command;
+import com.jagrosh.jdautilities.command.CommandEvent;
+import com.mcmoddev.mmdbot.core.Utils;
+import com.mcmoddev.mmdbot.utilities.quotes.Quote;
+import com.mcmoddev.mmdbot.utilities.quotes.QuoteList;
+import net.dv8tion.jda.api.entities.TextChannel;
+
+import java.util.Random;
+
+/**
+ * Get a quote from the list.
+ * Allows an int argument, otherwise random is chosen.
+ *
+ * Possible forms:
+ *   !quote
+ *   !quote 111
+ *
+ * Can be used by anyone.
+ *
+ * TODO: Prepare for more Quote implementations.
+ *
+ * @author Curle
+ */
+public final class CmdGetQuote extends Command {
+
+    /**
+     * Create the command.
+     * Sets all the usual flags.
+     */
+    public CmdGetQuote() {
+        super();
+        name = "getquote";
+        aliases = new String[] { "quote", "get-quote", "quoteget", "viewquote" };
+        help = "Get a quote. Specify a number if you like, otherwise a random is chosen.";
+    }
+
+    @Override
+    protected void execute(final CommandEvent event) {
+        if (!Utils.checkCommand(this, event))
+            return;
+
+        final TextChannel channel = event.getTextChannel();
+        String argsFull = event.getArgs();
+
+        // Check whether any parameters given.
+        if (argsFull.length() > 0) {
+            // We have something to parse.
+            try {
+                int index = Integer.parseInt(argsFull.trim());
+                if (index >= QuoteList.getQuoteSlot()) {
+                    channel.sendMessageEmbeds(QuoteList.getQuoteNotPresent()).queue();
+                    return;
+                }
+
+                Quote fetched = QuoteList.getQuote(index);
+
+                // Check if the quote exists.
+                if (fetched == QuoteList.NULL) {
+                    // Send the standard message
+                    channel.sendMessageEmbeds(QuoteList.getQuoteNotPresent()).queue();
+                    return;
+                }
+
+                // It exists, so get the content and send it.
+                assert fetched != null;
+                channel.sendMessageEmbeds(fetched.getQuoteMessage()).queue();
+                return;
+            } catch (NumberFormatException ignored) {
+                // Fall through to the code below. No number found, so pick a random one.
+            }
+        }
+
+        // Get a random quote.
+        int limit = QuoteList.getQuoteSlot() - 1;
+        int index = new Random().nextInt(limit);
+        Quote fetched = QuoteList.getQuote(index);
+
+        // Check if the quote exists.
+        if (fetched == null) {
+            // Send the standard message
+            channel.sendMessageEmbeds(QuoteList.getQuoteNotPresent()).queue();
+            return;
+        }
+
+        // It exists, so get the content and send it.
+        channel.sendMessageEmbeds(fetched.getQuoteMessage()).queue();
+
+    }
+}

--- a/src/main/java/com/mcmoddev/mmdbot/modules/commands/server/quotes/CmdRemoveQuote.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/commands/server/quotes/CmdRemoveQuote.java
@@ -1,0 +1,54 @@
+package com.mcmoddev.mmdbot.modules.commands.server.quotes;
+
+import com.jagrosh.jdautilities.command.Command;
+import com.jagrosh.jdautilities.command.CommandEvent;
+import com.mcmoddev.mmdbot.core.Utils;
+import com.mcmoddev.mmdbot.utilities.quotes.QuoteList;
+import net.dv8tion.jda.api.entities.TextChannel;
+
+/**
+ * Remove a quote from the list.
+ * Requires an int argument.
+ *
+ * Possible forms:
+ *   !removequote 5
+ *
+ * Can only be used by Bot Maintainers and higher.
+ *
+ * @author Curle
+ */
+public final class CmdRemoveQuote extends Command {
+
+    /**
+     * Create the command.
+     * Sets all the usual flags.
+     */
+    public CmdRemoveQuote() {
+        super();
+        name = "removequote";
+        aliases = new String[] { "quote-remove", "remove-quote" };
+        help = "Remove a quote from the list.";
+        requiredRole = "bot maintainer";
+    }
+
+    @Override
+    protected void execute(final CommandEvent event) {
+        if (!Utils.checkCommand(this, event))
+            return;
+
+        final TextChannel channel = event.getTextChannel();
+        String argsFull = event.getArgs();
+        if (argsFull.length() > 0) {
+            // We have something to parse.
+            try {
+                int index = Integer.parseInt(argsFull.trim());
+                QuoteList.removeQuote(index);
+                channel.sendMessage("Quote " + index + " removed.").queue();
+            } catch (NumberFormatException ignored) {
+                channel.sendMessage("Unable to determine which quote to remove.").queue();
+            }
+        } else {
+            channel.sendMessage("Specify a quote ID to remove.").queue();
+        }
+    }
+}

--- a/src/main/java/com/mcmoddev/mmdbot/utilities/quotes/IQuote.java
+++ b/src/main/java/com/mcmoddev/mmdbot/utilities/quotes/IQuote.java
@@ -1,0 +1,63 @@
+package com.mcmoddev.mmdbot.utilities.quotes;
+
+import net.dv8tion.jda.api.entities.MessageEmbed;
+
+/**
+ * The interface which all Quote types implement.
+ * Provides an interface for retrieving quote metadata.
+ *
+ * Quote metadata consists of:
+ *  - Quotee; One of:
+ *    - Discord User ID
+ *    - String (for users not in MMD, or for external sources)
+ *  - Author:
+ *    - Discord User ID
+ *  - Data; Serialized instance of a Quote
+ *  - ID; An integer representing the place this quote holds in the list.
+ *
+ * Allows an arbitrary amount of "types" of quotes.
+ *
+ * @author Curle
+ */
+public interface IQuote {
+
+    /**
+     * @return The person or object being quoted.
+     */
+    UserReference getQuotee();
+
+    /**
+     * Set a new quotee.
+     * @param quotee The person or object being quoted.
+     */
+    void setQuotee(UserReference quotee);
+
+    /**
+     * @return The person or object that created this quote.
+     */
+    UserReference getQuoteAuthor();
+
+    /**
+     * Set a new quote author.
+     * @param author The person or object that created this quote.
+     */
+    void setQuoteAuthor(UserReference author);
+
+    /**
+     * @return The integer ID of this quote.
+     */
+    int getID();
+
+    /**
+     * Set a new ID.
+     * @param id The integer ID of this quote.
+     */
+    void setID(int id);
+
+    /**
+     * Turn this quote's data into an Embed to be sent in a channel.
+     * @return A fully formed Embed ready for sending.
+     */
+    MessageEmbed getQuoteMessage();
+
+}

--- a/src/main/java/com/mcmoddev/mmdbot/utilities/quotes/NullQuote.java
+++ b/src/main/java/com/mcmoddev/mmdbot/utilities/quotes/NullQuote.java
@@ -1,0 +1,24 @@
+package com.mcmoddev.mmdbot.utilities.quotes;
+
+import net.dv8tion.jda.api.entities.MessageEmbed;
+
+/**
+ * Used in place of null in the serialized list of quotes.
+ *
+ * @author Curle
+ */
+public final class NullQuote extends Quote {
+
+    @Override
+    public MessageEmbed getQuoteMessage() {
+        return QuoteList.getQuoteNotPresent();
+    }
+
+    /**
+     * Create a new NullQuote.
+     */
+    public NullQuote() {
+        this.setQuotee(null);
+        this.setQuoteAuthor(null);
+    }
+}

--- a/src/main/java/com/mcmoddev/mmdbot/utilities/quotes/Quote.java
+++ b/src/main/java/com/mcmoddev/mmdbot/utilities/quotes/Quote.java
@@ -1,0 +1,94 @@
+package com.mcmoddev.mmdbot.utilities.quotes;
+
+/**
+ * Handles the attribution aspect of a Quote.
+ *
+ * Exists to be the superclass to implementations that hold data.
+ * As such, it is abstract so that the data and thus getQuoteMessage() function may be undefined.
+ *
+ * A quote is serialized as such:
+ *  {
+ *      "ID": DATA,
+ *      "quotee": {
+ *          "type": DATA,
+ *          "data": DATA
+ *      },
+ *      "creator": {
+ *          "type": DATA,
+ *          "data": DATA
+ *      },
+ *      "content": {
+ *          < HANDLED BY IMPLEMENTATION >
+ *      }
+ *  }
+ *
+ * @author Curle
+ */
+public abstract class Quote implements IQuote {
+
+    /**
+     * The user or thing being quoted.
+     */
+    protected UserReference quotee;
+
+    /**
+     * The user or thing that created the quote.
+     */
+    protected UserReference creator;
+
+    /**
+     * The ID of this quote; representing where in the list it is.
+     */
+    protected int id;
+
+    /**
+     * Set the creator of this Quote.
+     * @param author A Reference to the User that created the Quote.
+     */
+    @Override
+    public void setQuoteAuthor(final UserReference author) {
+        this.creator = author;
+    }
+
+    /**
+     * @return The person or object being quoted.
+     */
+    @Override
+    public UserReference getQuoteAuthor() {
+        return creator;
+    }
+
+    /**
+     * Set the target of this Quote.
+     * @param target A Reference to the User being Quoted.
+     */
+    @Override
+    public void setQuotee(final UserReference target) {
+        this.quotee = target;
+    }
+
+    /**
+     * @return The person or object that created this quote.
+     */
+    @Override
+    public UserReference getQuotee() {
+        return quotee;
+    }
+
+    /**
+     * Set the ID of this Quote.
+     * @param pId The integer representing where in the list the Quote is.
+     */
+    @Override
+    public void setID(final int pId) {
+        this.id = pId;
+    }
+
+    /**
+     * @return The integer representing where in the list the Quote is.
+     */
+    @Override
+    public int getID() {
+        return id;
+    }
+}

--- a/src/main/java/com/mcmoddev/mmdbot/utilities/quotes/QuoteList.java
+++ b/src/main/java/com/mcmoddev/mmdbot/utilities/quotes/QuoteList.java
@@ -1,0 +1,261 @@
+package com.mcmoddev.mmdbot.utilities.quotes;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+import com.mcmoddev.mmdbot.MMDBot;
+import com.mcmoddev.mmdbot.core.References;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import org.jetbrains.annotations.Nullable;
+
+import java.awt.Color;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The storage container and manager for Quotes.
+ *
+ * Contains the logic needed to add, remove, read and write the quotes contained within.
+ *
+ * Most of this code is taken from willbl's Tricks.class file.
+ *
+ * TODO: Migrate to SQLite.
+ * TODO: Fix the mess i made trying to get subclasses to serialize and deserialize.
+ * @author Curle
+ */
+public final class QuoteList {
+
+    private QuoteList() { }
+
+    /**
+     * Location to the quote storage file.
+     */
+    private static final String QUOTE_STORAGE = "quotes.json";
+
+    /**
+     * The Gson instance used for serialization and deserialization.
+     */
+    private static final Gson GSON = new GsonBuilder()
+        .registerTypeAdapterFactory(new QuoteSerializer())
+        .create();
+
+    /**
+     * The static instance of NullQuote used as the reference for nulls.
+     * Stops the GSON parser from entering an infinite loop.
+     */
+    public static final NullQuote NULL = new NullQuote();
+
+    /**
+     * The list of Quote instances held by this container.
+     * Quote metadata ID should sync with the index in this list.
+     * This greatly simplifies access operations.
+     */
+    private static List<Quote> quotes = null;
+
+    /**
+     * The message used for when quotes are null, or do not exist.
+     */
+    private static final MessageEmbed QUOTE_NOT_PRESENT = new EmbedBuilder()
+        .setAuthor(References.NAME, MMDBot.getInstance().getSelfUser().getAvatarUrl())
+        .setTitle("Quote")
+        .setColor(Color.GREEN)
+        .addField("Warning", "Specified quote does not exist.", false)
+        .setTimestamp(Instant.now())
+        .build();
+
+    /**
+     * Given a numeric ID, fetch the quote at that index, or null.
+     * @param id The index to fetch the quote from.
+     * @return The Quote object at that index.
+     */
+    @Nullable
+    public static Quote getQuote(final int id) {
+        if (quotes == null)
+            loadQuotes();
+
+        return quotes.get(id);
+    }
+
+    /**
+     * Load quotes from file.
+     *
+     * Has minimal error handling.
+     */
+    public static void loadQuotes() {
+        if (quotes != null)
+            return;
+
+        final File quoteFile = new File(QUOTE_STORAGE);
+        if (!quoteFile.exists())
+            quotes = new ArrayList<>();
+
+        try (InputStreamReader reader = new InputStreamReader(new FileInputStream(quoteFile), StandardCharsets.UTF_8)) {
+
+            Type listType = new TypeToken<List<Quote>>() { }.getType();
+            quotes = GSON.fromJson(reader, listType);
+
+        } catch (final IOException exception) {
+            MMDBot.LOGGER.trace("Failed to read quote file...", exception);
+            quotes = new ArrayList<>();
+        }
+    }
+
+    /**
+     * Write quotes to disk.
+     *
+     * Has minimal error handling.
+     */
+    private static void syncQuotes() {
+        final File quoteFile = new File(QUOTE_STORAGE);
+        try (OutputStreamWriter writer =
+                 new OutputStreamWriter(new FileOutputStream(quoteFile), StandardCharsets.UTF_8)) {
+            GSON.toJson(quotes, writer);
+        } catch (Exception exception) {
+            MMDBot.LOGGER.trace("Failed to write quote file...", exception);
+        }
+    }
+
+    /**
+     * Add the specified quote to the list at the specified index.
+     * @param quote The quote to add.
+     */
+    public static void addQuote(final Quote quote) {
+        if (quotes == null)
+            loadQuotes();
+
+        quotes.add(quote.getID(), quote);
+        syncQuotes();
+    }
+
+    /**
+     * Removes the specified quote from the list.
+     * If the quote is at the end of the list, it will be replaced with the next addition.
+     * If the quote is at any point before the start of the list, it will cause a null gap.
+     * If the quote is at the start of a null gap and the null gap is at the end of the list, it will close the gap.
+     * If the quote is after the end of the list, it will have no effect.
+     * @param id the ID of the item to remove.
+     */
+    public static void removeQuote(final int id) {
+        if (quotes == null)
+            loadQuotes();
+
+        quotes.set(id, NULL);
+
+        // Count the number of nulls at the end of the list
+        int index = 0;
+        int nullElements = 0;
+        while (index < quotes.size()) {
+            if (quotes.get(index) != NULL) {
+                nullElements = 0;
+                index++;
+                continue;
+            }
+
+            nullElements++;
+            index++;
+        }
+
+        // Remove extras if necessary
+        if (nullElements > 0)
+            quotes.subList(quotes.size() - nullElements, quotes.size()).clear();
+
+        // Write to disk
+        syncQuotes();
+    }
+
+    /**
+     * Get the index of the end of the list.
+     * Does NOT find any holes before the end of the list.
+     * TODO: Make this fill holes
+     * For generating the next Quote ID.
+     * @return The index of the next empty slot in the list.
+     */
+    public static int getQuoteSlot() {
+        if (quotes == null)
+            loadQuotes();
+
+        return quotes.size();
+    }
+
+
+    /**
+     * @return The message used for when quotes are null, or do not exist.
+     */
+    public static MessageEmbed getQuoteNotPresent() {
+        return QUOTE_NOT_PRESENT;
+    }
+
+
+    static final class QuoteSerializer implements TypeAdapterFactory {
+
+        public <T> TypeAdapter<T> create(final Gson gson, final TypeToken<T> type) {
+            if (!Quote.class.isAssignableFrom(type.getRawType()))
+                return null;
+
+            // Fetch the Gson adapter that'd otherwise be used to serialize/deserialize this object
+            final TypeAdapter<T> adapter = gson.getDelegateAdapter(this, type);
+
+            // Create a new TypeAdapter, that..
+            return new TypeAdapter<>() {
+
+                // When asked to serialize..
+                @Override
+                public void write(final JsonWriter out, final T value) throws IOException {
+                    out.beginObject();
+                    // Writes { "type": "StringQuote" }
+                    out.name("type").value(type.toString());
+                    // Writes { "value": DATA }
+                    out.name("value");
+                    // And passes the serialization onto Gson's internal handlers.
+                    adapter.write(out, value);
+                    out.endObject();
+                }
+                // And when asked to read...
+                @Override
+                public T read(final JsonReader in) throws IOException {
+                    if (in.peek() == JsonToken.NULL)
+                        return null;
+
+                    in.beginObject();
+
+
+                    // Makes sure the type we wrote is there,
+                    if (!"type".equals(in.nextName()))
+                        return null;
+
+                    try {
+                        // Retrieves the class name we wrote,
+                        Class<T> clazz = (Class<T>) Class.forName(in.nextString());
+                        // Retrieves the TypeToken for the class,
+                        TypeToken<T> readerType = TypeToken.get(clazz);
+
+                        in.nextName(); // Skip value
+                        // And passes on reading to Gson's internal handlers.
+                        T result = gson.getDelegateAdapter(QuoteSerializer.this, readerType).read(in);
+                        in.endObject();
+                        return result;
+                        // Except, when the class doesn't exist, it passes on the RuntimeError.
+                    } catch (ClassNotFoundException exception) {
+                        throw new RuntimeException(exception);
+                    }
+                }
+            };
+        }
+    }
+
+}

--- a/src/main/java/com/mcmoddev/mmdbot/utilities/quotes/StringQuote.java
+++ b/src/main/java/com/mcmoddev/mmdbot/utilities/quotes/StringQuote.java
@@ -1,0 +1,110 @@
+package com.mcmoddev.mmdbot.utilities.quotes;
+
+import com.mcmoddev.mmdbot.MMDBot;
+import com.mcmoddev.mmdbot.core.References;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.internal.entities.UserById;
+
+import java.awt.Color;
+import java.time.Instant;
+
+/**
+ * A Quote implementation that encodes a String as the thing being quoted.
+ *
+ * A StringQuote is serialized as such:
+ *   {
+ *       DATA
+ *   }
+ *
+ * @author Curle
+ */
+public final class StringQuote extends Quote {
+
+    /**
+     * The String that is the message or content being quoted.
+     */
+    private String data;
+
+    /**
+     * Set the String encoding the Quote data.
+     * @param pData The message or content being quoted.
+     */
+    protected void setData(final String pData) {
+        this.data = pData;
+    }
+
+    /**
+     * @return The message or content being quoted.
+     */
+    protected String getData() {
+        return data;
+    }
+
+    @Override
+    public MessageEmbed getQuoteMessage() {
+        EmbedBuilder builder = new EmbedBuilder();
+        builder.setAuthor(References.NAME, MMDBot.getInstance().getSelfUser().getAvatarUrl());
+        builder.setTitle("Quote " + this.getID());
+        builder.setColor(Color.GREEN);
+        builder.addField("Content", this.getData(), false);
+
+        // Resolve the person being quoted.
+        UserReference quotee = this.getQuotee();
+        switch (quotee.getReferenceType()) {
+            case SNOWFLAKE:
+                UserById user = new UserById(quotee.getSnowflakeData());
+                builder.addField("Author", user.getAsMention(), false);
+                break;
+            case STRING:
+                builder.addField("Author", quotee.getStringData(), false);
+                break;
+
+            case ANONYMOUS: // Intentional fallthrough.
+            default:
+                builder.addField("Author", quotee.getAnonymousData(), false);
+                break;
+        }
+
+        // Resolve the person that made the quote..
+        UserReference author = this.getQuoteAuthor();
+        switch (author.getReferenceType()) {
+            case SNOWFLAKE:
+                // Try to find the user's data in a server
+                User user = MMDBot.getInstance().getUserById(author.getSnowflakeData());
+                // If we have it...
+                if (user != null) {
+                    // Use it
+                    builder.setFooter("Quoted by " + user.getAsTag());
+                } else {
+                    // Otherwise, fall back to the snowflake.
+                    builder.setFooter("Quoted by " + author.getSnowflakeData());
+                }
+                break;
+            case STRING:
+                builder.setFooter("Quoted by " + author.getStringData());
+                break;
+
+            case ANONYMOUS: // Intentional fallthrough.
+            default:
+                builder.setFooter("Quoted by " + author.getAnonymousData());
+                break;
+        }
+
+        builder.setTimestamp(Instant.now());
+        return builder.build();
+    }
+
+    /**
+     * Construct a new StringQuote with all the necessary data.
+     * @param quotee A Reference to the User being Quoted.
+     * @param quote The message or content being Quoted.
+     * @param creator A Reference to the User that created the Quote.
+     */
+    public StringQuote(final UserReference quotee, final String quote, final UserReference creator) {
+        this.setQuotee(quotee);
+        this.setData(quote);
+        this.setQuoteAuthor(creator);
+    }
+}

--- a/src/main/java/com/mcmoddev/mmdbot/utilities/quotes/UserReference.java
+++ b/src/main/java/com/mcmoddev/mmdbot/utilities/quotes/UserReference.java
@@ -1,0 +1,205 @@
+package com.mcmoddev.mmdbot.utilities.quotes;
+
+/**
+ * The information containing "who" or "what" a quote is referencing.
+ * Can be for either the thing being quoted, or the thing that created the quote.
+ *
+ * Designed to only be directly read by the Quotes utility class.
+ * Some design decisions are implemented to take advantage of that while maintaining flexibility.
+ *
+ * @author Curle
+ */
+public final class UserReference {
+
+    /**
+     * Identifies which of the fields in this class should be read to retrieve the proper data.
+     */
+    private ReferenceType referenceType;
+
+    /**
+     * The data for a SNOWFLAKE reference.
+     *
+     * Encodes a Discord User ID as a Snowflake.
+     */
+    private long snowflakeData;
+
+    /**
+     * The data for a STRING reference.
+     *
+     * Encodes an arbitrary source that can be appended to the output.
+     */
+    private String stringData;
+
+    /**
+     * The data for an ANONYMOUS reference.
+     *
+     * Encodes the string "Anonymous" which is always returned as the source.
+     */
+    private String anonymousData = "Anonymous";
+
+    /**
+     * Identifies which of the fields in this class should be read to retrieve the proper data.
+     * @return The Reference Type of this User Reference.
+     */
+    public ReferenceType getReferenceType() {
+        return referenceType;
+    }
+
+    /**
+     * Set the Type of the current Reference.
+     * @param pReferenceType The new Type to take over
+     */
+    public void setReferenceType(final ReferenceType pReferenceType) {
+        this.referenceType = pReferenceType;
+    }
+
+    /**
+     * The data for a SNOWFLAKE reference.
+     *
+     * Encodes a Discord User ID as a Snowflake.
+     *
+     * @return The encoded user ID as a long form snowflake.
+     */
+    public long getSnowflakeData() {
+        return snowflakeData;
+    }
+
+    /**
+     * Set the snowflake data of the current Reference.
+     * @param pSnowflakeData The Snowflake data to take over
+     */
+    public void setSnowflakeData(final long pSnowflakeData) {
+        this.snowflakeData = pSnowflakeData;
+    }
+
+    /**
+     * The data for a STRING reference.
+     *
+     * Encodes an arbitrary source that can be appended to the output.
+     *
+     * @return The encoded String reference,
+     */
+    public String getStringData() {
+        return stringData;
+    }
+
+    /**
+     * Set the String data of the current Reference.
+     * @param pStringData The String data to take over
+     */
+    public void setStringData(final String pStringData) {
+        this.stringData = pStringData;
+    }
+
+    /**
+     * The data for an ANONYMOUS reference.
+     *
+     * Encodes the string "Anonymous" which is always returned as the source.
+     *
+     * @return The string "Anonymous".
+     */
+    public String getAnonymousData() {
+        return anonymousData;
+    }
+
+    /**
+     * A Quote can reference one of these things:
+     * - A Discord user
+     * - An external source
+     * - An anonymous source.
+     *
+     * The String name is encoded into this enum to facilitate de/serialization.
+     * TODO: this can probably be replaced with a two-way map.
+     */
+    public enum ReferenceType {
+        /**
+         * Discord User ID.
+         */
+        SNOWFLAKE("snowflake"),
+
+        /**
+         * External named source.
+         */
+        STRING("string"),
+
+        /**
+         * Hacker group. Er, an unnamed source.
+         */
+        ANONYMOUS("anonymous");
+
+        /**
+         * Holds the String representation of the name of the enum entry.
+         */
+        private final String name;
+
+        /**
+         * Construct a new ReferenceType.
+         * Internal use only.
+         * @param pName String representation of the name.
+         */
+        ReferenceType(final String pName) {
+            this.name = pName;
+        }
+
+        /**
+         * Retrieve the name of this enum entry, as a String.
+         * For serialization.
+         * @return The name of this enum entry, as a String.
+         */
+        public String getName() {
+            return this.name;
+        }
+
+        /**
+         * Get ReferenceType instance from the name.
+         * For deserialization.
+         * @param pName The name of the enum value to retrieve.
+         * @return The ReferenceType value requested.
+         */
+        public static ReferenceType of(final String pName) {
+            switch (pName) {
+                case "snowflake": return SNOWFLAKE;
+                case "string": return STRING;
+                default:
+                case "anonymous": return ANONYMOUS;
+            }
+        }
+
+    }
+
+
+    /**
+     * No attribution constructor.
+     * Sets the referenceType to ANONYMOUS.
+     */
+    public UserReference() {
+        setReferenceType(ReferenceType.ANONYMOUS);
+        setSnowflakeData(0);
+        setStringData("");
+    }
+
+    /**
+     * SNOWFLAKE attribution constructor.
+     * Sets the referenceType to SNOWFLAKE.
+     * Sets the snowflakeData field to the given ID.
+     * @param id The Discord User ID as a Snowflake for the user to reference.
+     */
+    public UserReference(final long id) {
+        setReferenceType(ReferenceType.SNOWFLAKE);
+        setSnowflakeData(id);
+        setStringData("");
+    }
+
+    /**
+     * STRING attribution constructor.
+     * Sets the referenceType to STRING.
+     * Sets the stringData field to the given String.
+     * @param source The String to use as the reference.
+     */
+    public UserReference(final String source) {
+        setReferenceType(ReferenceType.STRING);
+        setStringData(source);
+        setSnowflakeData(0);
+    }
+
+}


### PR DESCRIPTION
### Quotes?

Quotes, as seen on Forgecord and many other servers, can be a fun way of keeping a community close and entertained.  
They provide a way of organizing the best utterances from a server, and laughing at the bizarre and absurd phrases that pop up in the modding circles.

In code, a Quote consists of four things;
- An ID
- A Quotee (the person that was quoted saying something)
- An Author (the person that decided the saying needed to be quoted)
- Extra Data.

The Extra Data is provided by an implementation of the Quote abstract class.  
Currently, that's singly StringQuote, but there are plans for more.

### Commands?

My PR implements three commands so far:

1. addquote; 
   - Takes a message to quote, as well as a source. Currently this can be done with `"text" - @User`, or `"text" - Some User String`. 
   - Can be run by anybody.
2. viewquote;
   - Takes an optional number for the ID. If none is given, a random quote is chosen. If one is given, that quote is shown.
   - Can be run by anybody.
3. removequote;
   - Takes a required number for the ID.
   - Removes the quote at the given ID.
   - If the given ID is before a valid quote, a hole is created. Quotes are not moved after being set. IDs are stable.
   - If the given ID opens a hole to the end of the list, the hole is purged and quotes may be added to fill the gap again.
   - Can be run only by bot maintainers.

The implementation of removequote is to facilitate such situations as:

* Two people (1 and 2) are engaged in conversation. They together say a phrase that, when taken out of context, is mildly hilarious.
* Two observers decide that the phrase shall be quoted. 
* The observer quoting 2 creates their quote (ID 55) before the person quoting 1 (ID 56), so now the quotes are out of order.
* Quote 55 is removed, creating a gap.

If it were to stop here, the gap could never be filled with quotes again. Quote 55 could be recreated to restore the original order of the quote, but at a mild inconvenience to onlookers.

However:
* Quote 56 is removed. Now the hole where 55 lays is opened to the end of the list.
* All of the items at the end of the list are purged, allowing a new quote to be made.
* The new quote takes the ID 55, with the original intended order.

It's convoluted, but this happens surprisingly often in servers where quote bots exist.

### Draft?

This PR is a draft because there is lots of unimplemented functionality.
Some TODOS:

1. Allow quote creators to remove their own quotes, alongside Bot Maintainers.
2. Move away from json & Gson, to the SQLite Database implemented in #45.
3. Image quotes; for snapshots of conversations, or XKCD-like sources.
 