### PR TITLE
Small miscellaneous fixes and changes

### DIFF
--- a/src/main/java/com/mcmoddev/mmdbot/modules/logging/misc/EventReactionAdded.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/logging/misc/EventReactionAdded.java
@@ -36,6 +36,16 @@ public final class EventReactionAdded extends ListenerAdapter {
     private final Set<Message> warnedMessages = new HashSet<>();
 
     /**
+     * The set of messages that have passed the reaction threshold required for request deletion, but are awaiting a
+     * staff member (a user with {@link Permission#KICK_MEMBERS}) to sign-off on the deletion by giving their own
+     * reaction.
+     *
+     * <p>If a message has been added previously to this set, and the message falls back below the request deletion
+     * threshold, it will be removed from this set.</p>
+     */
+    private final Set<Long> messagesAwaitingSignoff = new HashSet<>();
+
+    /**
      * On message reaction add.
      *
      * @param event the event
@@ -92,7 +102,8 @@ public final class EventReactionAdded extends ListenerAdapter {
 
             final User messageAuthor = message.getAuthor();
             if (requestScore >= removalThreshold) {
-                if (!hasStaffSignoff) {
+                // If the message has no staff signing off and it hasn't yet been logged about, log it
+                if (!hasStaffSignoff && messagesAwaitingSignoff.add(message.getIdLong())) {
                     LOGGER.info(REQUESTS, "Request from {} has a score of {}, reaching removal threshold {}, "
                             + "awaiting moderation approval.",
                         messageAuthor, requestScore, removalThreshold);
@@ -169,6 +180,10 @@ public final class EventReactionAdded extends ListenerAdapter {
                     action = action.onErrorFlatMap(throwable -> discussionChannel.sendMessage(response));
                 }
                 action.queue();
+            }
+            // Remove messages under the removal threshold from the awaiting sign-off set
+            if (requestScore < removalThreshold) {
+                messagesAwaitingSignoff.remove(message.getIdLong());
             }
         }
     }

--- a/src/main/java/com/mcmoddev/mmdbot/utilities/oldchannels/OldChannelsHelper.java
+++ b/src/main/java/com/mcmoddev/mmdbot/utilities/oldchannels/OldChannelsHelper.java
@@ -15,7 +15,7 @@ public class OldChannelsHelper {
     /**
      * The constant channelLastMessageMap.
      */
-    private static final Map<TextChannel, Long> CHANNEL_LAST_MESSAGE_MAP = new HashMap<>();
+    private static final Map<Long, Long> CHANNEL_LAST_MESSAGE_MAP = new HashMap<>();
 
     /**
      * The constant ready.
@@ -29,7 +29,7 @@ public class OldChannelsHelper {
      * @return the last message time
      */
     public static long getLastMessageTime(final TextChannel channel) {
-        return CHANNEL_LAST_MESSAGE_MAP.getOrDefault(channel, -1L);
+        return CHANNEL_LAST_MESSAGE_MAP.getOrDefault(channel.getIdLong(), -1L);
     }
 
     /**
@@ -47,7 +47,7 @@ public class OldChannelsHelper {
      * @param timeSinceLastMessage the time since last message
      */
     public static void put(final TextChannel channel, final long timeSinceLastMessage) {
-        CHANNEL_LAST_MESSAGE_MAP.put(channel, timeSinceLastMessage);
+        CHANNEL_LAST_MESSAGE_MAP.put(channel.getIdLong(), timeSinceLastMessage);
     }
 
     /**


### PR DESCRIPTION
This PR contains a few small miscellaneous fixes and changes.

## Commit List

- **Fix staff sign-off code causing out-of-bounds error**

  The original code queried the first item in the users without checking if the list has any contents. This led to an IndexOutOfBoundsException when querying an empty list, and also means that if the staff member used another emote other than the first one in the list (which _may_ be possible depending on configuration), it wouldn't register the staff sign-off.

- **Add millis threshold to disconnect message**

  This filters out 'normal' disconnections, avoiding warning logspam while making note of notably long disconnections. Disconnections are always logged to DEBUG in any case.

- **Adjust message checker to ignore inaccessible channels**

  A channel is inaccessible if the bot user cannot view the channel or see the message history in the channel.

- **Store longs instead of TextChannels in old-channels helper**

  Storing the text channel means that the object will live on even if JDA discards the object, and will be a constant burden in the bot's memory. Using the snowflake ID of the channel is better memory-wise, and avoids storing JDA entities long-term.

---

- **Store messages awaiting sign-off in in-memory set**

  Without this, the bot would always log about the message awaiting sign-off every time it gets a reaction above the deletion limit.


