### PR TITLE
Migrate data to SQLite database

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,9 @@ dependencies {
   implementation group: 'me.shedaniel', name: 'linkie-core', version: "${project.linkie_version}"
   implementation group: 'org.jetbrains.kotlinx', name: 'kotlinx-coroutines-core', version: "${project.ktx_coroutines_version}"
   implementation group: 'org.jetbrains.kotlinx', name: 'kotlinx-coroutines-jdk8', version: "${project.ktx_coroutines_version}"
+  implementation group: 'org.flywaydb', name: 'flyway-core', version: "${project.flyway_version}"
+  implementation group: 'org.jdbi', name: 'jdbi3-core', version: "${project.jdbi_version}"
+  implementation group: 'org.jdbi', name: 'jdbi3-sqlobject', version: "${project.jdbi_version}"
 
   testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: "${project.junit_version}"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,3 +11,5 @@ junit_version=5.7.2
 findsecbugs_version=1.11.0
 linkie_version=1.0.81
 ktx_coroutines_version=1.5.1
+flyway_version=7.12.1
+jdbi_version=3.21.0

--- a/src/main/java/com/mcmoddev/mmdbot/MMDBot.java
+++ b/src/main/java/com/mcmoddev/mmdbot/MMDBot.java
@@ -5,10 +5,13 @@ import com.mcmoddev.mmdbot.core.References;
 import com.mcmoddev.mmdbot.modules.commands.CommandModule;
 import com.mcmoddev.mmdbot.modules.logging.LoggingModule;
 import com.mcmoddev.mmdbot.modules.logging.misc.MiscEvents;
+import com.mcmoddev.mmdbot.utilities.database.DatabaseManager;
+import com.mcmoddev.mmdbot.utilities.database.JSONDataMigrator;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
 import net.dv8tion.jda.api.requests.GatewayIntent;
 import net.dv8tion.jda.api.utils.cache.CacheFlag;
+import org.jdbi.v3.core.Jdbi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,6 +51,11 @@ public final class MMDBot {
      */
     private static JDA instance;
 
+    /**
+     * The database manager.
+     */
+    private static DatabaseManager database;
+
     static {
         MMDBot.INTENTS.add(GatewayIntent.DIRECT_MESSAGES);
         MMDBot.INTENTS.add(GatewayIntent.GUILD_BANS);
@@ -76,6 +84,21 @@ public final class MMDBot {
     }
 
     /**
+     * {@return the database manager}
+     */
+    public static DatabaseManager getDatabaseManager() {
+        return database;
+    }
+
+    /**
+     * {@return the Jdbi instance from the database manager}
+     * @see DatabaseManager#jdbi()
+     */
+    public static Jdbi database() {
+        return database.jdbi();
+    }
+
+    /**
      * The main method.
      *
      * @param args Arguments provided to the program.
@@ -99,6 +122,8 @@ public final class MMDBot {
         }
 
         try {
+            MMDBot.database = DatabaseManager.connectSQLite("jdbc:sqlite:./data.db");
+            JSONDataMigrator.checkAndMigrate(MMDBot.database);
             MMDBot.instance = JDABuilder
                 .create(MMDBot.config.getToken(), MMDBot.INTENTS)
                 .disableCache(CacheFlag.VOICE_STATE)

--- a/src/main/java/com/mcmoddev/mmdbot/core/References.java
+++ b/src/main/java/com/mcmoddev/mmdbot/core/References.java
@@ -54,16 +54,6 @@ public class References {
     public static final String COMMANDS = "commands.";
 
     /**
-     * The constant STICKY_ROLES_FILE_PATH.
-     */
-    public static final String STICKY_ROLES_FILE_PATH = "mmdbot_sticky_roles.json";
-
-    /**
-     * The constant USER_JOIN_TIMES_FILE_PATH.
-     */
-    public static final String USER_JOIN_TIMES_FILE_PATH = "mmdbot_user_join_times.json";
-
-    /**
      * The constant STARTUP_TIME.
      */
     public static Instant STARTUP_TIME;

--- a/src/main/java/com/mcmoddev/mmdbot/core/Utils.java
+++ b/src/main/java/com/mcmoddev/mmdbot/core/Utils.java
@@ -21,6 +21,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Objects;
 import java.util.StringJoiner;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -183,6 +184,7 @@ public final class Utils {
         return MMDBot.database().withExtension(PersistedRoles.class, roles -> roles.getRoles(userID))
             .stream()
             .map(guild::getRoleById)
+            .filter(Objects::nonNull)
             .toList();
     }
 

--- a/src/main/java/com/mcmoddev/mmdbot/modules/logging/users/EventUserJoined.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/logging/users/EventUserJoined.java
@@ -1,6 +1,8 @@
 package com.mcmoddev.mmdbot.modules.logging.users;
 
+import com.mcmoddev.mmdbot.MMDBot;
 import com.mcmoddev.mmdbot.core.Utils;
+import com.mcmoddev.mmdbot.utilities.database.dao.PersistedRoles;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.IMentionable;
 import net.dv8tion.jda.api.entities.Role;
@@ -54,6 +56,7 @@ public final class EventUserJoined extends ListenerAdapter {
                         LOGGER.warn(EVENTS, "Unable to give member {} role {}: {}", member, role, ex.getMessage());
                     }
                 }
+                MMDBot.database().useExtension(PersistedRoles.class, persist -> persist.clear(user.getIdLong()));
             }
             final var embed = new EmbedBuilder();
             embed.setColor(Color.GREEN);

--- a/src/main/java/com/mcmoddev/mmdbot/modules/logging/users/EventUserLeft.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/logging/users/EventUserLeft.java
@@ -1,7 +1,6 @@
 package com.mcmoddev.mmdbot.modules.logging.users;
 
 import com.mcmoddev.mmdbot.MMDBot;
-import com.mcmoddev.mmdbot.core.Utils;
 import com.mcmoddev.mmdbot.utilities.console.MMDMarkers;
 import com.mcmoddev.mmdbot.utilities.database.dao.PersistedRoles;
 import com.mcmoddev.mmdbot.utilities.database.dao.UserFirstJoins;

--- a/src/main/java/com/mcmoddev/mmdbot/utilities/database/DatabaseManager.java
+++ b/src/main/java/com/mcmoddev/mmdbot/utilities/database/DatabaseManager.java
@@ -50,9 +50,9 @@ public class DatabaseManager {
     }
 
     /**
-     * Constructs a {@code DatabaseManager} using the provided data source. {@link Flyway#migrate()} Flyway migration}
-     * is invoked on the database. Note that the databases connection returned by the data source must not require any
-     * username or password to connect.
+     * Constructs a {@code DatabaseManager} using the provided data source. {@linkplain Flyway#migrate() Flyway
+     * migration} is invoked on the database. Note that the databases connection returned by the data source must not
+     * require any username or password to connect.
      *
      * @param dataSource the SQL data source
      */

--- a/src/main/java/com/mcmoddev/mmdbot/utilities/database/DatabaseManager.java
+++ b/src/main/java/com/mcmoddev/mmdbot/utilities/database/DatabaseManager.java
@@ -1,31 +1,86 @@
 package com.mcmoddev.mmdbot.utilities.database;
 
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.SQLException;
+import org.flywaydb.core.Flyway;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.sqlobject.SqlObjectPlugin;
+import org.jdbi.v3.sqlobject.customizer.TimestampedConfig;
+import org.sqlite.SQLiteDataSource;
+
+import javax.sql.DataSource;
+import java.time.ZoneOffset;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 /**
- * The type Database manager.
+ * Manager type for the backing SQL database for MMDBot.
+ *
+ * <p>The database manager makes use of {@link Jdbi} for accessing the database through fluent or DAO-based APIs, and
+ * {@link Flyway} to automatically migrate the database to the schemas that this version of the bot understands.</p>
  *
  * @author Antoine Gagnon
+ * @author sciwhiz12
  */
 public class DatabaseManager {
+    /**
+     * The data source connected to the database which is used by the application.
+     */
+    private final DataSource dataSource;
 
     /**
-     * Gets connection.
-     *
-     * @return the connection
+     * The JDBI instance linked to the {@linkplain #dataSource database}.
      */
-    public static Connection getConnection() {
-        Connection conn = null;
-        try {
-            // db parameters
-            String url = "jdbc:sqlite:./data.db";
-            // create a connection to the database
-            conn = DriverManager.getConnection(url);
-        } catch (SQLException e) {
-            System.out.println(e.getMessage());
-        }
-        return conn;
+    private final Jdbi jdbi;
+
+    /**
+     * Creates a {@code DatabaseManager} by creating a {@link SQLiteDataSource} pointing at the SQLite database
+     * specified by the URL.
+     *
+     * @param url the url of the SQLite database to connect to
+     * @return a database manager connected to the specifiedSQLite database
+     * @throws IllegalArgumentException if the URL does not start with the {@code jdbc:sqlite:} prefix
+     */
+    public static DatabaseManager connectSQLite(final String url) {
+        checkArgument(url.startsWith("jdbc:sqlite:"), "SQLite DB URL does not start with 'jdbc:sqlite:': %s", url);
+
+        SQLiteDataSource dataSource = new SQLiteDataSource();
+        dataSource.setUrl(url);
+        dataSource.setDatabaseName("mmdbot");
+
+        return new DatabaseManager(dataSource);
+    }
+
+    /**
+     * Constructs a {@code DatabaseManager} using the provided data source. {@link Flyway#migrate()} Flyway migration}
+     * is invoked on the database. Note that the databases connection returned by the data source must not require any
+     * username or password to connect.
+     *
+     * @param dataSource the SQL data source
+     */
+    public DatabaseManager(final DataSource dataSource) {
+        this.dataSource = dataSource;
+        this.jdbi = Jdbi.create(dataSource);
+
+        // Install the SQL Objects and Guava plugins
+        jdbi.installPlugin(new SqlObjectPlugin());
+        // Set default timezone to UTC
+        jdbi.getConfig(TimestampedConfig.class).setTimezone(ZoneOffset.UTC);
+
+        // Perform Flyway migration on the database
+        final Flyway flyway = Flyway.configure().dataSource(dataSource).load();
+        flyway.migrate();
+    }
+
+    /**
+     * {@return the SQL data source}
+     */
+    public DataSource getDataSource() {
+        return dataSource;
+    }
+
+    /**
+     * {@return the JDBI instance linked to the database this manager is connected to}
+     */
+    public Jdbi jdbi() {
+        return jdbi;
     }
 }

--- a/src/main/java/com/mcmoddev/mmdbot/utilities/database/JSONDataMigrator.java
+++ b/src/main/java/com/mcmoddev/mmdbot/utilities/database/JSONDataMigrator.java
@@ -1,0 +1,204 @@
+package com.mcmoddev.mmdbot.utilities.database;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import com.jagrosh.jdautilities.commons.utils.SafeIdUtil;
+import com.mcmoddev.mmdbot.utilities.database.dao.PersistedRoles;
+import com.mcmoddev.mmdbot.utilities.database.dao.UserFirstJoins;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+/**
+ * Migrates data from the old JSON flat-file storage to the SQL database tables.
+ *
+ * @author sciwhiz12
+ */
+public final class JSONDataMigrator {
+    /**
+     * The logger for this class.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(JSONDataMigrator.class);
+
+    /**
+     * The shared Gson instance, used to load JSON files.
+     */
+    private static final Gson GSON = new Gson();
+    /**
+     * The type token for the user first join times data, which represents a {@code Map<String, Instant>}.
+     */
+    private static final TypeToken<?> USER_FIRST_JOIN_TIMES_TYPE = TypeToken.getParameterized(
+        Map.class, String.class, Instant.class);
+    /**
+     * The type token for the stick roles data, which represents a {@code Map<String, List<String>>}.
+     */
+    private static final TypeToken<?> STICKY_ROLES_TYPE = TypeToken.getParameterized(
+        Map.class, String.class, TypeToken.getParameterized(List.class, String.class).getType());
+
+    /**
+     * The extension appended to JSON data files once their data has been migrated.
+     */
+    private static final String MIGRATED_FILE_EXTENSION = ".old";
+    /**
+     * The name of the JSON file that contains the user first join times data.
+     */
+    public static final String USER_JOIN_TIMES_FILE_PATH = "mmdbot_user_join_times.json";
+    /**
+     * The name of the JSON file that contains the sticky roles data.
+     */
+    public static final String STICKY_ROLES_FILE_PATH = "mmdbot_sticky_roles.json";
+
+    /**
+     * Utility classes should not be constructed.
+     */
+    private JSONDataMigrator() { // Prevent instantiation
+    }
+
+    /**
+     * Checks for existing JSON files and migrates them to the database if they exist. JSON data migrations which fail
+     * due to file loading or SQL errors will not cause the application to stop, but the file will remain in place to
+     * allow repeating the migration for the next time this method is called (on application bootup).
+     *
+     * @param database the database manager
+     */
+    public static void checkAndMigrate(final DatabaseManager database) {
+        LOGGER.debug("Checking for JSON files to migrate");
+
+        // User first join times
+        Path joinTimesFile = Path.of(USER_JOIN_TIMES_FILE_PATH);
+        if (Files.exists(joinTimesFile) && Files.isRegularFile(joinTimesFile) && Files.isReadable(joinTimesFile)) {
+            LOGGER.info("Found JSON file for user first join times data, migrating...");
+
+            migrate("user first join times", joinTimesFile, reader -> {
+                final Map<String, Instant> joinTimes = GSON.fromJson(reader, USER_FIRST_JOIN_TIMES_TYPE.getType());
+                database.jdbi().useExtension(UserFirstJoins.class, j -> j.useTransaction(joins ->
+                    joinTimes.forEach((idStr, timestamp) -> {
+                        final long id = SafeIdUtil.safeConvert(idStr);
+                        if (id == 0L) {
+                            LOGGER.warn("Could not parse user ID {}", idStr);
+                        } else {
+                            if (joins.get(id).isEmpty()) {
+                                joins.insert(id, timestamp);
+                            }
+                        }
+                    })
+                ));
+            });
+
+            LOGGER.info("Migrated user first join times data");
+        }
+
+        // Sticky roles
+        Path rolesFile = Path.of(STICKY_ROLES_FILE_PATH);
+        if (Files.exists(rolesFile) && Files.isRegularFile(rolesFile) && Files.isReadable(rolesFile)) {
+            LOGGER.info("Found JSON file for sticky roles data, migrating...");
+
+            migrate("sticky roles", rolesFile, reader -> {
+                final Map<String, List<String>> joinTimes = GSON.fromJson(reader, STICKY_ROLES_TYPE.getType());
+
+                database.jdbi().useExtension(PersistedRoles.class, r -> r.useTransaction(roles ->
+                    joinTimes.forEach((idStr, rolesList) -> {
+                        final long id = SafeIdUtil.safeConvert(idStr);
+                        if (id == 0L) {
+                            LOGGER.warn("Could not parse user ID {}", idStr);
+                        } else {
+                            roles.insert(id, rolesList.stream()
+                                .map(SafeIdUtil::safeConvert)
+                                .filter(s -> s != 0)
+                                .toList());
+                        }
+                    })
+                ));
+            });
+
+            LOGGER.info("Migrated sticky roles data");
+        }
+    }
+
+    /**
+     * Performs a migration on the data from the given file using the given consumer. The consumer is passed a
+     * {@link Reader} which is opened on the given file (which does not need to be closed by the consumer). After the
+     * consumer does its operation, the given file is then renamed according to {@link #renameMigratedFile(Path)}.
+     *
+     * <p>If an exception occurs while loading the data or while performing SQL operations, the exception is logged
+     * using the given {@code migrateType} string in the log message to describe the migration. The file is only
+     * renamed if there are no exceptions thrown.</p>
+     *
+     * @param migrateType a string describing what migration is taking place
+     * @param file        the file containing the data to be migrated
+     * @param migrator    the operation which migrates the data using the passed in reader
+     * @param <T>         the throwable
+     * @throws T used to sneakily throw caught throwables without the JVM requiring caller methods to catch or declare
+     *           the exception in their method signature
+     */
+    @SuppressWarnings("unchecked")
+    private static <T extends Throwable> void migrate(final String migrateType, final Path file,
+                                                      final ThrowingConsumer<Reader> migrator) throws T {
+        try (var reader = Files.newBufferedReader(file, StandardCharsets.UTF_8)) {
+            migrator.acceptThrows(reader);
+
+            renameMigratedFile(file);
+        } catch (final IOException exception) {
+            LOGGER.warn("""
+                    Could not load %s data for migration.
+                    Please fix the error, and restart the application to try migration again.""".formatted(migrateType),
+                exception);
+        } catch (final Throwable exception) {
+            if (exception instanceof SQLException) {
+                LOGGER.warn("""
+                        Could not insert %s data into database.
+                        Please fix the error, and restart the application to try migration again.""".formatted(migrateType),
+                    exception);
+                return;
+            }
+            throw (T) exception;
+        }
+    }
+
+    /**
+     * Renames the file to append the {@link #MIGRATED_FILE_EXTENSION} ({@value #MIGRATED_FILE_EXTENSION}), and logs
+     * any exceptions silently.
+     *
+     * @param file the file to rename
+     */
+    private static void renameMigratedFile(final Path file) {
+        try {
+            Files.move(file, file.resolveSibling(file.getFileName() + MIGRATED_FILE_EXTENSION),
+                StandardCopyOption.REPLACE_EXISTING);
+        } catch (final IOException exception) {
+            LOGGER.warn("Failed to rename migrated data file {}", file, exception);
+        }
+    }
+
+    /**
+     * Represents an operation that accepts a single input argument and returns no
+     * result, which may throw an exception. Like its non-throwing counterpart,
+     * {@code ThrowingConsumer} is expected to operate via side-effects.
+     *
+     * <p>This is a <a href="package-summary.html">functional interface</a>
+     * whose functional method is {@link #acceptThrows(Object)}.</p>
+     *
+     * @param <T> the type of the input to the operation
+     * @see Consumer
+     */
+    @FunctionalInterface
+    private interface ThrowingConsumer<T> {
+        /**
+         * Performs this operation on the given argument, potentially throwing an exception.
+         *
+         * @param t the input argument
+         */
+        void acceptThrows(T t) throws Exception;
+    }
+}

--- a/src/main/java/com/mcmoddev/mmdbot/utilities/database/dao/PersistedRoles.java
+++ b/src/main/java/com/mcmoddev/mmdbot/utilities/database/dao/PersistedRoles.java
@@ -1,0 +1,67 @@
+package com.mcmoddev.mmdbot.utilities.database.dao;
+
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+import org.jdbi.v3.sqlobject.transaction.Transactional;
+
+import java.util.List;
+
+/**
+ * Data access object for the role persistence table.
+ *
+ * @author sciwhiz12
+ */
+public interface PersistedRoles extends Transactional<PersistedRoles> {
+
+    /// Insertion methods ///
+
+    /**
+     * Inserts an entry for the given user and role into the table.
+     *
+     * @param userId the snowflake ID of the user
+     * @param roleId the snowflake ID of the role
+     */
+    @SqlUpdate("insert into role_persist values (:user, :role)")
+    void insert(@Bind("user") long userId, @Bind("role") long roleId);
+
+    /**
+     * Inserts an entry for each role in the given iterable with the given user into the table.
+     *
+     * @param userId the snowflake ID of the user
+     * @param roles  an iterable of snowflake IDs of roles
+     */
+    default void insert(long userId, Iterable<Long> roles) {
+        roles.forEach(roleId -> insert(userId, roleId));
+    }
+
+    /// Query methods ///
+
+    /**
+     * Gets the stored roles for the given user.
+     *
+     * @param userId the snowflake ID of the user
+     * @return the list of role snowflake IDs which are associated with the user
+     */
+    @SqlQuery("select role_id from role_persist where user_id = :user")
+    List<Long> getRoles(@Bind("user") long userId);
+
+    /// Deletion methods ///
+
+    /**
+     * Delete the entry for the given user and role from the table.
+     *
+     * @param userId the snowflake ID of the user
+     * @param roleId the snowflake ID of the role
+     */
+    @SqlUpdate("delete from role_persist where user_id = :user and role_id = :role")
+    void delete(@Bind("user") long userId, @Bind("role") long roleId);
+
+    /**
+     * Clears all entries for the given user from the table.
+     *
+     * @param userId the snowflake ID of the user
+     */
+    @SqlUpdate("delete from role_persist where user_id = :user")
+    void clear(@Bind("user") long userId);
+}

--- a/src/main/java/com/mcmoddev/mmdbot/utilities/database/dao/UserFirstJoins.java
+++ b/src/main/java/com/mcmoddev/mmdbot/utilities/database/dao/UserFirstJoins.java
@@ -1,0 +1,39 @@
+package com.mcmoddev.mmdbot.utilities.database.dao;
+
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+import org.jdbi.v3.sqlobject.transaction.Transactional;
+
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * Data access object for the user first join times table.
+ *
+ * @author sciwhiz12
+ */
+public interface UserFirstJoins extends Transactional<UserFirstJoins> {
+
+    /// Insertion methods ///
+
+    /**
+     * Inserts the given join timestamp for the given user into the table.
+     *
+     * @param user      the snowflake ID of the user
+     * @param timestamp the join timestamp
+     */
+    @SqlUpdate("insert or ignore into first_join values (:user, :timestamp)")
+    void insert(@Bind("user") long user, @Bind("timestamp") Instant timestamp);
+
+    /// Query methods ///
+
+    /**
+     * Gets the join timestamp for the given user from the table.
+     *
+     * @param user the snowflake ID of the user
+     * @return an optional containing the join timestamp for the given user
+     */
+    @SqlQuery("select first_joined_at from first_join where user_id = :user")
+    Optional<Instant> get(@Bind("user") long user);
+}

--- a/src/main/java/com/mcmoddev/mmdbot/utilities/database/dao/package-info.java
+++ b/src/main/java/com/mcmoddev/mmdbot/utilities/database/dao/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Data access objects for the backing application database, for use with Jdbi as extensions.
+ *
+ * @see org.jdbi.v3.core.Jdbi#withExtension(java.lang.Class, org.jdbi.v3.core.extension.ExtensionCallback)
+ * @see org.jdbi.v3.core.Jdbi#useExtension(java.lang.Class, org.jdbi.v3.core.extension.ExtensionConsumer)
+ */
+package com.mcmoddev.mmdbot.utilities.database.dao;

--- a/src/main/java/com/mcmoddev/mmdbot/utilities/quotes/Quote.java
+++ b/src/main/java/com/mcmoddev/mmdbot/utilities/quotes/Quote.java
@@ -7,7 +7,7 @@ package com.mcmoddev.mmdbot.utilities.quotes;
  * As such, it is abstract so that the data and thus getQuoteMessage() function may be undefined.
  *
  * A quote is serialized as such:
- *  {
+ * <pre>{@code {
  *      "ID": DATA,
  *      "quotee": {
  *          "type": DATA,
@@ -20,7 +20,7 @@ package com.mcmoddev.mmdbot.utilities.quotes;
  *      "content": {
  *          < HANDLED BY IMPLEMENTATION >
  *      }
- *  }
+ *  }}</pre>
  *
  * @author Curle
  */

--- a/src/main/resources/db/migration/V1__initial_setup.sql
+++ b/src/main/resources/db/migration/V1__initial_setup.sql
@@ -1,0 +1,10 @@
+create table first_join (
+    user_id unsigned big int unique not null primary key,
+    first_joined_at datetime not null
+);
+
+create table role_persist (
+    user_id unsigned big int not null,
+    role_id unsigned big int not null,
+    primary key (user_id, role_id)
+);


### PR DESCRIPTION
This PR starts the migration of the existing data storage structures to use the SQLite database, which was sitting unused before this PR. This continues the work started in #45 by @antoinegag, by implementing the SQLite database into the bot.

## Added libraries

To ease the pain of manually writing JDBC code for everything, we use Jdbi as an intermediate library between JDBC and us. While using a full ORM (like Hibernate) would be a possible solution, in my opinion, it would be too heavy for our use.

Flyway's Java API is added to handle migrations of the database in the actual production environment, as opposed to the Gradle plugin which is for development instead.

## Migration

As of writing, two features are moved to using the SQLite database: the **role persistence** feature, and the **guild first join time tracker** feature.

The sticky roles (what I call role persistence) and user join times data are migrated automatically on launch if the relevant files exist, then they are renamed to not trigger migration on next boot but still keep the data just in case there are problems with the migration.

When the tricks data is also moved to being in the database (whether in this PR or in a future), a corresponding automatic migration will be implemented.