### PR TITLE
Mini Cleanup.

### DIFF
--- a/src/main/java/com/mcmoddev/mmdbot/modules/commands/CommandModule.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/commands/CommandModule.java
@@ -48,6 +48,7 @@ import com.mcmoddev.mmdbot.modules.commands.server.moderation.CmdUnmute;
 import com.mcmoddev.mmdbot.modules.commands.server.moderation.CmdUser;
 import com.mcmoddev.mmdbot.modules.commands.server.quotes.CmdAddQuote;
 import com.mcmoddev.mmdbot.modules.commands.server.quotes.CmdGetQuote;
+import com.mcmoddev.mmdbot.modules.commands.server.quotes.CmdListQuotes;
 import com.mcmoddev.mmdbot.modules.commands.server.quotes.CmdRemoveQuote;
 import com.mcmoddev.mmdbot.modules.commands.server.tricks.CmdAddTrick;
 import com.mcmoddev.mmdbot.modules.commands.server.tricks.CmdListTricks;
@@ -120,6 +121,7 @@ public class CommandModule {
             .addCommand(new CmdAddQuote())
             .addCommand(new CmdGetQuote())
             .addCommand(new CmdRemoveQuote())
+            .addCommand(new CmdListQuotes())
             .setHelpWord("help")
             .build();
 
@@ -128,6 +130,7 @@ public class CommandModule {
             MMDBot.getInstance().addEventListener(CmdMappings.ButtonListener.INSTANCE);
             MMDBot.getInstance().addEventListener(CmdTranslateMappings.ButtonListener.INSTANCE);
             MMDBot.getInstance().addEventListener(new CmdListTricks.ButtonListener());
+            MMDBot.getInstance().addEventListener(new CmdListQuotes.ButtonListener());
             MMDBot.LOGGER.warn("Command module enabled and loaded.");
         } else {
             MMDBot.LOGGER.warn("Command module disabled via config, commands will not work at this time!");

--- a/src/main/java/com/mcmoddev/mmdbot/modules/commands/bot/info/CmdUptime.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/commands/bot/info/CmdUptime.java
@@ -28,7 +28,8 @@ import net.dv8tion.jda.api.EmbedBuilder;
 
 import java.awt.Color;
 import java.time.Instant;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 
 /**
  * The type Cmd uptime.
@@ -59,9 +60,8 @@ public class CmdUptime extends Command {
 
         embed.setTitle("Time spent online.");
         embed.setColor(Color.GREEN);
-        //TODO Fix utils that handle time to show hours and minuets too.
-        embed.addField("I've been online for: ", Utils.getTimeDifference(Utils.getLocalTime(
-            References.STARTUP_TIME), LocalDateTime.now()), false);
+        embed.addField("I've been online for: ", Utils.getTimeDifference(Utils.getTimeFromUTC(
+            References.STARTUP_TIME), OffsetDateTime.now(ZoneOffset.UTC)), false);
         embed.setTimestamp(Instant.now());
         channel.sendMessageEmbeds(embed.build()).queue();
     }

--- a/src/main/java/com/mcmoddev/mmdbot/modules/commands/bot/info/CmdUptime.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/commands/bot/info/CmdUptime.java
@@ -62,8 +62,8 @@ public class CmdUptime extends Command {
         embed.setTitle("Time spent online.");
         embed.setColor(Color.GREEN);
         embed.addField("I've been online for: ", Utils.getTimeDifference(Utils.getTimeFromUTC(
-            References.STARTUP_TIME), OffsetDateTime.now(ZoneOffset.UTC),
-            ChronoUnit.YEARS, ChronoUnit.MONTHS, ChronoUnit.DAYS, ChronoUnit.HOURS, ChronoUnit.HOURS, ChronoUnit.SECONDS)
+                    References.STARTUP_TIME), OffsetDateTime.now(ZoneOffset.UTC),
+                ChronoUnit.YEARS, ChronoUnit.MONTHS, ChronoUnit.DAYS, ChronoUnit.HOURS, ChronoUnit.HOURS, ChronoUnit.SECONDS)
             , false);
         embed.setTimestamp(Instant.now());
         channel.sendMessageEmbeds(embed.build()).queue();

--- a/src/main/java/com/mcmoddev/mmdbot/modules/commands/bot/info/CmdUptime.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/commands/bot/info/CmdUptime.java
@@ -30,6 +30,7 @@ import java.awt.Color;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
 
 /**
  * The type Cmd uptime.
@@ -61,7 +62,9 @@ public class CmdUptime extends Command {
         embed.setTitle("Time spent online.");
         embed.setColor(Color.GREEN);
         embed.addField("I've been online for: ", Utils.getTimeDifference(Utils.getTimeFromUTC(
-            References.STARTUP_TIME), OffsetDateTime.now(ZoneOffset.UTC)), false);
+            References.STARTUP_TIME), OffsetDateTime.now(ZoneOffset.UTC),
+            ChronoUnit.YEARS, ChronoUnit.MONTHS, ChronoUnit.DAYS, ChronoUnit.HOURS, ChronoUnit.HOURS, ChronoUnit.SECONDS)
+            , false);
         embed.setTimestamp(Instant.now());
         channel.sendMessageEmbeds(embed.build()).queue();
     }

--- a/src/main/java/com/mcmoddev/mmdbot/modules/commands/general/info/CmdMe.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/commands/general/info/CmdMe.java
@@ -21,8 +21,8 @@
 package com.mcmoddev.mmdbot.modules.commands.general.info;
 
 import com.jagrosh.jdautilities.command.CommandEvent;
-import com.mcmoddev.mmdbot.utilities.Utils;
 import com.mcmoddev.mmdbot.modules.commands.server.moderation.CmdUser;
+import com.mcmoddev.mmdbot.utilities.Utils;
 import net.dv8tion.jda.api.EmbedBuilder;
 
 /**

--- a/src/main/java/com/mcmoddev/mmdbot/modules/commands/general/mappings/CmdMappings.kt
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/commands/general/mappings/CmdMappings.kt
@@ -67,7 +67,7 @@ class CmdMappings(name: String, private val namespace: Namespace, vararg aliases
 
         scope.launch {
             val provider = namespace.getProvider(version)
-                var embeds = query(provider, queryString)
+            var embeds = query(provider, queryString)
                 .mapIndexed { idx, it ->
                     async {
                         @Suppress("UNCHECKED_CAST")
@@ -131,12 +131,13 @@ class CmdMappings(name: String, private val namespace: Namespace, vararg aliases
                 }.iterator()
 
             if (!embeds.hasNext()) {
-                embeds = listOf(async { EmbedBuilder()
-                    .setTitle("$namespace mapping for $version:")
-                    .setDescription("No results found.")
-                    .setFooter("Powered by linkie-core")
-                    .setColor(Color.RED)
-                    .build()
+                embeds = listOf(async {
+                    EmbedBuilder()
+                        .setTitle("$namespace mapping for $version:")
+                        .setDescription("No results found.")
+                        .setFooter("Powered by linkie-core")
+                        .setColor(Color.RED)
+                        .build()
                 }).iterator()
             }
 
@@ -176,7 +177,7 @@ class CmdMappings(name: String, private val namespace: Namespace, vararg aliases
             var hasPerfectMatch = false
             return (
                     MappingsQuery.queryClasses(context).value.asSequence()
-                    + MappingsQuery.queryMember(context) { it.members.asSequence() }.value.asSequence()
+                            + MappingsQuery.queryMember(context) { it.members.asSequence() }.value.asSequence()
                     )
                 .sortedBy { it.score }
                 .also { seq ->

--- a/src/main/java/com/mcmoddev/mmdbot/modules/commands/general/mappings/CmdTranslateMappings.kt
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/commands/general/mappings/CmdTranslateMappings.kt
@@ -31,7 +31,8 @@ import me.shedaniel.linkie.*
 import me.shedaniel.linkie.namespaces.MCPNamespace
 import me.shedaniel.linkie.namespaces.MojangNamespace
 import me.shedaniel.linkie.namespaces.YarnNamespace
-import me.shedaniel.linkie.utils.*
+import me.shedaniel.linkie.utils.ResultHolder
+import me.shedaniel.linkie.utils.tryToVersion
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.events.interaction.ButtonClickEvent
@@ -39,11 +40,22 @@ import net.dv8tion.jda.api.hooks.ListenerAdapter
 import net.dv8tion.jda.api.interactions.components.Button
 import java.awt.Color
 import java.util.*
+import kotlin.collections.Iterator
+import kotlin.collections.MutableMap
+import kotlin.collections.getOrElse
+import kotlin.collections.listOf
+import kotlin.collections.mutableMapOf
+import kotlin.collections.set
 
 /**
  * @author Will BL
  */
-class CmdTranslateMappings(name: String, private val namespace1: Namespace, private val namespace2: Namespace, vararg aliases: String?) : Command() {
+class CmdTranslateMappings(
+    name: String,
+    private val namespace1: Namespace,
+    private val namespace2: Namespace,
+    vararg aliases: String?
+) : Command() {
     init {
         this.name = name.lowercase(Locale.ROOT)
         this.aliases = aliases
@@ -65,7 +77,8 @@ class CmdTranslateMappings(name: String, private val namespace1: Namespace, priv
         val query = args[0];
         val version = args.getOrElse(1) {
             val namespace2Versions = namespace2.getAllVersions().toSet()
-            namespace1.getAllVersions().filter { version -> namespace2Versions.contains(version) }.maxWithOrNull(nullsFirst(compareBy { it.tryToVersion() }))!!
+            namespace1.getAllVersions().filter { version -> namespace2Versions.contains(version) }
+                .maxWithOrNull(nullsFirst(compareBy { it.tryToVersion() }))!!
         }
 
         scope.launch {
@@ -79,58 +92,59 @@ class CmdTranslateMappings(name: String, private val namespace1: Namespace, priv
                 .map { res -> res to translate(res, targetMappings) }
                 .filter { it.second != null }
                 .mapIndexed { idx, it ->
-                        val originalResult = it.first
-                        val translation = it.second
+                    val originalResult = it.first
+                    val translation = it.second
 
-                        @Suppress("UNCHECKED_CAST")
-                        when (translation) {
-                            is Class -> {
-                                val value = originalResult.value as Class
-                                EmbedBuilder()
-                                    .setTitle("$originMappingsName -> $targetMappingsName Class mapping for $version:")
-                                    .run {
-                                        if (value.mappedName != null)
-                                            addField("$originMappingsName Name", "`${value.mappedName}`", false)
-                                        else this
-                                    }
-                                    .addField("Intermediary/SRG Name", "`${value.intermediaryName}`", false)
-                                    .addField("Obfuscated Name", "`${value.obfName.merged}`", false)
-                                    .addField("$targetMappingsName Name", "`${translation.optimumName}`", false)
-                            }
-                            is MappingsMember -> {
-                                val value = originalResult.value as Pair<Class, MappingsMember>
-                                EmbedBuilder()
-                                    .setTitle(
-                                        "$originMappingsName -> $targetMappingsName ${
-                                            when (value.second) {
-                                                is Field -> "Field"
-                                                is Method -> "Method"
-                                                else -> "Member"
-                                            }
-                                        } mapping for $version:"
-                                    )
-                                    .addField("$originMappingsName Name", "`${value.second.mappedName}`", false)
-                                    .addField(
-                                        "Intermediary/SRG Name",
-                                        "`${value.second.intermediaryName}`",
-                                        false
-                                    )
-                                    .addField("Obfuscated Name", "`${value.second.obfName.merged}`", false)
-                                    .addField("$targetMappingsName Name", "`${translation.optimumName}`", false)
-                            }
-                            else -> {
-                                EmbedBuilder().setDescription("???")
-                            }
-                        }.setFooter("Page ${idx + 1} | Powered by linkie-core").build()
+                    @Suppress("UNCHECKED_CAST")
+                    when (translation) {
+                        is Class -> {
+                            val value = originalResult.value as Class
+                            EmbedBuilder()
+                                .setTitle("$originMappingsName -> $targetMappingsName Class mapping for $version:")
+                                .run {
+                                    if (value.mappedName != null)
+                                        addField("$originMappingsName Name", "`${value.mappedName}`", false)
+                                    else this
+                                }
+                                .addField("Intermediary/SRG Name", "`${value.intermediaryName}`", false)
+                                .addField("Obfuscated Name", "`${value.obfName.merged}`", false)
+                                .addField("$targetMappingsName Name", "`${translation.optimumName}`", false)
+                        }
+                        is MappingsMember -> {
+                            val value = originalResult.value as Pair<Class, MappingsMember>
+                            EmbedBuilder()
+                                .setTitle(
+                                    "$originMappingsName -> $targetMappingsName ${
+                                        when (value.second) {
+                                            is Field -> "Field"
+                                            is Method -> "Method"
+                                            else -> "Member"
+                                        }
+                                    } mapping for $version:"
+                                )
+                                .addField("$originMappingsName Name", "`${value.second.mappedName}`", false)
+                                .addField(
+                                    "Intermediary/SRG Name",
+                                    "`${value.second.intermediaryName}`",
+                                    false
+                                )
+                                .addField("Obfuscated Name", "`${value.second.obfName.merged}`", false)
+                                .addField("$targetMappingsName Name", "`${translation.optimumName}`", false)
+                        }
+                        else -> {
+                            EmbedBuilder().setDescription("???")
+                        }
+                    }.setFooter("Page ${idx + 1} | Powered by linkie-core").build()
                 }.iterator()
 
             if (!embeds.hasNext()) {
-                embeds = listOf(EmbedBuilder()
-                    .setTitle("$namespace1 -> $namespace2 Class mapping for $version:")
+                embeds = listOf(
+                    EmbedBuilder()
+                        .setTitle("$namespace1 -> $namespace2 Class mapping for $version:")
                         .setDescription("No results found.")
-                    .setFooter("Powered by linkie-core")
-                    .setColor(Color.RED)
-                    .build()
+                        .setFooter("Powered by linkie-core")
+                        .setColor(Color.RED)
+                        .build()
                 ).iterator()
             }
 
@@ -170,13 +184,25 @@ class CmdTranslateMappings(name: String, private val namespace1: Namespace, priv
                 val parent = value.first as Class
                 val member = value.second as Field
 
-                member.obfMergedName?.let { memberName -> parent.obfMergedName?.let { className -> target.getClassByObfName(className)?.getFieldByObfName(memberName) } }
+                member.obfMergedName?.let { memberName ->
+                    parent.obfMergedName?.let { className ->
+                        target.getClassByObfName(
+                            className
+                        )?.getFieldByObfName(memberName)
+                    }
+                }
             }
             value is Pair<*, *> && value.second is Method -> {
                 val parent = value.first as Class
                 val member = value.second as Method
 
-                member.obfMergedName?.let { memberName -> parent.obfMergedName?.let { className -> target.getClassByObfName(className)?.getMethodByObfName(memberName) } }
+                member.obfMergedName?.let { memberName ->
+                    parent.obfMergedName?.let { className ->
+                        target.getClassByObfName(
+                            className
+                        )?.getMethodByObfName(memberName)
+                    }
+                }
             }
             else -> null
         }

--- a/src/main/java/com/mcmoddev/mmdbot/modules/commands/server/CmdGuild.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/commands/server/CmdGuild.java
@@ -28,7 +28,8 @@ import net.dv8tion.jda.api.EmbedBuilder;
 import java.awt.Color;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Locale;
 
 /**
@@ -74,8 +75,8 @@ public final class CmdGuild extends Command {
         embed.addField("Role count:", Long.toString(guild.getRoleCache().size()), true);
         embed.addField("Date created:", new SimpleDateFormat("yyyy/MM/dd HH:mm",
             Locale.ENGLISH).format(dateGuildCreated.toEpochMilli()), true);
-        embed.addField("Guilds age:", Utils.getTimeDifference(Utils.getLocalTime(dateGuildCreated),
-            LocalDateTime.now()), true);
+        embed.addField("Guilds age:", Utils.getTimeDifference(Utils.getTimeFromUTC(dateGuildCreated),
+            OffsetDateTime.now(ZoneOffset.UTC)), true);
         embed.setTimestamp(Instant.now());
         channel.sendMessageEmbeds(embed.build()).queue();
     }

--- a/src/main/java/com/mcmoddev/mmdbot/modules/commands/server/moderation/CmdUser.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/commands/server/moderation/CmdUser.java
@@ -29,7 +29,8 @@ import net.dv8tion.jda.api.entities.Member;
 import java.awt.Color;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Locale;
 
 /**
@@ -98,8 +99,8 @@ public class CmdUser extends Command {
         final var date = new SimpleDateFormat("yyyy/MM/dd HH:mm", Locale.ENGLISH);
         embed.addField("Joined Discord:", date.format(dateJoinedDiscord.toEpochMilli()), true);
         embed.addField("Joined MMD:", date.format(dateJoinedMMD.toEpochMilli()), true);
-        embed.addField("Member for:", Utils.getTimeDifference(Utils.getLocalTime(dateJoinedMMD),
-            LocalDateTime.now()), true);
+        embed.addField("Member for:", Utils.getTimeDifference(Utils.getTimeFromUTC(dateJoinedMMD),
+            OffsetDateTime.now(ZoneOffset.UTC)), true);
         embed.setTimestamp(Instant.now());
 
         return embed;

--- a/src/main/java/com/mcmoddev/mmdbot/modules/commands/server/quotes/CmdAddQuote.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/commands/server/quotes/CmdAddQuote.java
@@ -53,7 +53,7 @@ public final class CmdAddQuote extends Command {
     public CmdAddQuote() {
         super();
         name = "addquote";
-        aliases = new String[] { "add-quote", "quoteadd", "quote-add" };
+        aliases = new String[]{"add-quote", "quoteadd", "quote-add"};
         help = "Adds a new Quote to the list.\nAdd a quote like so: !addquote \"I said something funny\" - author";
     }
 
@@ -75,7 +75,7 @@ public final class CmdAddQuote extends Command {
         }
 
         // Verify that there's a message being quoted.
-        if (!(args[0].charAt(0) == '\"') || !(args[0].charAt(args[0].length() - 2) == '\"') ) {
+        if (!(args[0].charAt(0) == '\"') || !(args[0].charAt(args[0].length() - 2) == '\"')) {
             channel.sendMessage("Invalid arguments. See the help for this command.").queue();
             return;
         }

--- a/src/main/java/com/mcmoddev/mmdbot/modules/commands/server/quotes/CmdAddQuote.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/commands/server/quotes/CmdAddQuote.java
@@ -54,7 +54,7 @@ public final class CmdAddQuote extends Command {
         super();
         name = "addquote";
         aliases = new String[] { "add-quote", "quoteadd", "quote-add" };
-        help = "Adds a new Quote to the list.\nAdd a quote like so: !addquote \"I said something funny - author\"!";
+        help = "Adds a new Quote to the list.\nAdd a quote like so: !addquote \"I said something funny\" - author";
     }
 
     @Override
@@ -75,7 +75,7 @@ public final class CmdAddQuote extends Command {
         }
 
         // Verify that there's a message being quoted.
-        if (!(args[0].charAt(0) == '\"') || !(args[0].charAt(args[0].length() - 3) == '\"') ) {
+        if (!(args[0].charAt(0) == '\"') || !(args[0].charAt(args[0].length() - 2) == '\"') ) {
             channel.sendMessage("Invalid arguments. See the help for this command.").queue();
             return;
         }

--- a/src/main/java/com/mcmoddev/mmdbot/modules/commands/server/quotes/CmdAddQuote.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/commands/server/quotes/CmdAddQuote.java
@@ -53,7 +53,7 @@ public final class CmdAddQuote extends Command {
     public CmdAddQuote() {
         super();
         name = "addquote";
-        aliases = new String[]{"add-quote", "quoteadd", "quote-add"};
+        aliases = new String[] { "add-quote", "quoteadd", "quote-add" };
         help = "Adds a new Quote to the list.\nAdd a quote like so: !addquote \"I said something funny - author\"!";
     }
 
@@ -69,13 +69,13 @@ public final class CmdAddQuote extends Command {
         // args = [ "text", <@ID> ]
 
         // Verify that there were any arguments
-        if (!(args.length > 0)) {
+        if (!(args.length > 0) || args.length > 2) {
             channel.sendMessage("Invalid arguments. See the help for this command.").queue();
             return;
         }
 
         // Verify that there's a message being quoted.
-        if (!(args[0].charAt(0) == '\"')) {
+        if (!(args[0].charAt(0) == '\"') || !(args[0].charAt(args[0].length() - 3) == '\"') ) {
             channel.sendMessage("Invalid arguments. See the help for this command.").queue();
             return;
         }

--- a/src/main/java/com/mcmoddev/mmdbot/modules/commands/server/quotes/CmdGetQuote.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/commands/server/quotes/CmdGetQuote.java
@@ -91,16 +91,14 @@ public final class CmdGetQuote extends Command {
             }
         }
 
-        // Get a random quote.
-        int limit = QuoteList.getQuoteSlot() - 1;
-        int index = new Random().nextInt(limit);
-        Quote fetched = QuoteList.getQuote(index);
-
-        // Check if the quote exists.
-        if (fetched == null) {
-            // Send the standard message
-            channel.sendMessageEmbeds(QuoteList.getQuoteNotPresent()).queue();
-            return;
+        Quote fetched = null;
+        // Find a valid quote.
+        while (fetched == null) {
+            // Get a random quote.
+            int limit = QuoteList.getQuoteSlot();
+            int index = new Random().nextInt(limit);
+            // If the next quote is null, we loop back and try again.
+            fetched = QuoteList.getQuote(index);
         }
 
         // It exists, so get the content and send it.

--- a/src/main/java/com/mcmoddev/mmdbot/modules/commands/server/quotes/CmdGetQuote.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/commands/server/quotes/CmdGetQuote.java
@@ -52,7 +52,7 @@ public final class CmdGetQuote extends Command {
     public CmdGetQuote() {
         super();
         name = "getquote";
-        aliases = new String[] { "quote", "get-quote", "quoteget", "viewquote" };
+        aliases = new String[]{"quote", "get-quote", "quoteget", "viewquote"};
         help = "Get a quote. Specify a number if you like, otherwise a random is chosen.";
     }
 
@@ -65,7 +65,7 @@ public final class CmdGetQuote extends Command {
         String argsFull = event.getArgs();
 
         // If there are no quotes, exit early.
-        if(QuoteList.getQuoteSlot() == 0) {
+        if (QuoteList.getQuoteSlot() == 0) {
             channel.sendMessageEmbeds(QuoteList.getQuoteNotPresent()).queue();
             return;
         }
@@ -103,7 +103,7 @@ public final class CmdGetQuote extends Command {
         do {
             int index = rand.nextInt(QuoteList.getQuoteSlot());
             fetched = QuoteList.getQuote(index);
-        } while ( fetched == null );
+        } while (fetched == null);
 
         // It exists, so get the content and send it.
         channel.sendMessageEmbeds(fetched.getQuoteMessage()).queue();

--- a/src/main/java/com/mcmoddev/mmdbot/modules/commands/server/quotes/CmdGetQuote.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/commands/server/quotes/CmdGetQuote.java
@@ -36,6 +36,7 @@ import java.util.Random;
  * Possible forms:
  * !quote
  * !quote 111
+ *
  * Can be used by anyone.
  *
  * TODO: Prepare for more Quote implementations.
@@ -51,7 +52,7 @@ public final class CmdGetQuote extends Command {
     public CmdGetQuote() {
         super();
         name = "getquote";
-        aliases = new String[]{"quote", "get-quote", "quoteget", "viewquote"};
+        aliases = new String[] { "quote", "get-quote", "quoteget", "viewquote" };
         help = "Get a quote. Specify a number if you like, otherwise a random is chosen.";
     }
 
@@ -62,6 +63,12 @@ public final class CmdGetQuote extends Command {
 
         final TextChannel channel = event.getTextChannel();
         String argsFull = event.getArgs();
+
+        // If there are no quotes, exit early.
+        if(QuoteList.getQuoteSlot() == 0) {
+            channel.sendMessageEmbeds(QuoteList.getQuoteNotPresent()).queue();
+            return;
+        }
 
         // Check whether any parameters given.
         if (argsFull.length() > 0) {
@@ -92,14 +99,11 @@ public final class CmdGetQuote extends Command {
         }
 
         Quote fetched = null;
-        // Find a valid quote.
-        while (fetched == null) {
-            // Get a random quote.
-            int limit = QuoteList.getQuoteSlot();
-            int index = new Random().nextInt(limit);
-            // If the next quote is null, we loop back and try again.
+        Random rand = new Random();
+        do {
+            int index = rand.nextInt(QuoteList.getQuoteSlot());
             fetched = QuoteList.getQuote(index);
-        }
+        } while ( fetched == null );
 
         // It exists, so get the content and send it.
         channel.sendMessageEmbeds(fetched.getQuoteMessage()).queue();

--- a/src/main/java/com/mcmoddev/mmdbot/modules/commands/server/quotes/CmdListQuotes.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/commands/server/quotes/CmdListQuotes.java
@@ -1,8 +1,26 @@
+/*
+ * MMDBot - https://github.com/MinecraftModDevelopment/MMDBot
+ * Copyright (C) 2016-2021 <MMD - MinecraftModDevelopment>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ */
 package com.mcmoddev.mmdbot.modules.commands.server.quotes;
 
 import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
-import com.mcmoddev.mmdbot.core.Utils;
+import com.mcmoddev.mmdbot.utilities.Utils;
 import com.mcmoddev.mmdbot.utilities.quotes.Quote;
 import com.mcmoddev.mmdbot.utilities.quotes.QuoteList;
 import net.dv8tion.jda.api.EmbedBuilder;
@@ -20,7 +38,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
-
 /**
  * Retrieve all quotes from the database.
  * Allows an int argument, otherwise starts from 0.
@@ -30,11 +47,10 @@ import java.util.List;
  * Implementation shamelessly stolen from willbl
  *
  * Possible forms:
- *      !quotes
- *      !quotes 155
  *
+ * !quotes
+ * !quotes 155
  * Can be used by anyone.
- *
  *
  * @author Curle
  */
@@ -49,50 +65,53 @@ public class CmdListQuotes extends Command {
     public CmdListQuotes() {
         super();
         name = "listquotes";
-        aliases = new String[] { "quotes", "list-quotes", "quoteslist" };
+        aliases = new String[]{"quotes", "list-quotes", "quoteslist"};
         help = "Get all quotes. Specify a starting number if you like, otherwise starts from 0.";
     }
 
 
     @Override
     protected void execute(final CommandEvent event) {
-        if (!Utils.checkCommand(this, event))
+        if (!Utils.checkCommand(this, event)) {
             return;
+        }
 
         final TextChannel channel = event.getTextChannel();
         String argsFull = event.getArgs();
         String[] args = argsFull.split(" ");
 
         int start = 0;
-        if(args.length > 1) {
+        if (args.length > 1) {
             start = Integer.parseInt(args[0]);
         }
 
-        MessageAction sentMessage = event.getChannel().sendMessageEmbeds(getQuotes(start).build());
-
+        MessageAction sentMessage = channel.sendMessageEmbeds(getQuotes(start).build());
         Component[] buttons = createButtons(start);
-        if (buttons.length > 0)
+        if (buttons.length > 0) {
             sentMessage.setActionRow(buttons);
+        }
 
         sentMessage.queue();
-
     }
 
     /**
      * Create the row of Component interaction buttons.
-     *
+     * <p>
      * Currently, this just creates a left and right arrow.
      * Left arrow scrolls back a page. Right arrow scrolls forward a page.
+     *
      * @param start The quote number at the start of the current page.
      * @return A row of buttons to go back and forth by one page in a quote list.
      */
     private static Component[] createButtons(int start) {
         List<Component> components = new ArrayList<>();
         if (start != 0) {
-            components.add(Button.secondary(ButtonListener.BUTTON_ID_PREFIX + "-" + start + "-prev", Emoji.fromUnicode("◀️")));
+            components.add(Button.secondary(ButtonListener.BUTTON_ID_PREFIX + "-" + start + "-prev",
+                Emoji.fromUnicode("◀️")));
         }
         if (start + QUOTE_PER_PAGE < QuoteList.getQuoteSlot()) {
-            components.add(Button.primary(ButtonListener.BUTTON_ID_PREFIX + "-" + start + "-next", Emoji.fromUnicode("▶️")));
+            components.add(Button.primary(ButtonListener.BUTTON_ID_PREFIX + "-" + start + "-next",
+                Emoji.fromUnicode("▶️")));
         }
         return components.toArray(new Component[0]);
     }
@@ -110,8 +129,9 @@ public class CmdListQuotes extends Command {
         // From the specified starting point until the end of the page..
         for (int x = start; x < start + QUOTE_PER_PAGE; x++) {
             // But stop early if we hit the end of the list,
-            if (x >= QuoteList.getQuoteSlot())
+            if (x >= QuoteList.getQuoteSlot()) {
                 break;
+            }
 
             // Get the current Quote
             Quote fetchedQuote = QuoteList.getQuote(x);
@@ -125,18 +145,18 @@ public class CmdListQuotes extends Command {
         }
 
         // We have to make sure that this doesn't crash if we list a fresh bot.
-        if (str.length() == 0)
+        if (str.length() == 0) {
             return new EmbedBuilder()
                 .setColor(Color.GREEN)
                 .setDescription("There are no quotes loaded currently.")
                 .setTimestamp(Instant.now());
-        else
+        } else {
             return new EmbedBuilder()
                 .setColor(Color.GREEN)
                 .setTitle("Quote Page " + ((start / QUOTE_PER_PAGE) + 1))
                 .setDescription(str.toString())
                 .setTimestamp(Instant.now());
-
+        }
     }
 
     public static class ButtonListener extends ListenerAdapter {
@@ -165,11 +185,13 @@ public class CmdListQuotes extends Command {
                     .editMessageEmbeds(getQuotes(current + QUOTE_PER_PAGE).build())
                     .setActionRow(createButtons(current + QUOTE_PER_PAGE))
                     .queue();
-            } else if (idParts[2].equals("prev")) {
-                event
-                    .editMessageEmbeds(getQuotes(current - QUOTE_PER_PAGE).build())
-                    .setActionRow(createButtons(current - QUOTE_PER_PAGE))
-                    .queue();
+            } else {
+                if (idParts[2].equals("prev")) {
+                    event
+                        .editMessageEmbeds(getQuotes(current - QUOTE_PER_PAGE).build())
+                        .setActionRow(createButtons(current - QUOTE_PER_PAGE))
+                        .queue();
+                }
             }
         }
     }

--- a/src/main/java/com/mcmoddev/mmdbot/modules/commands/server/quotes/CmdListQuotes.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/commands/server/quotes/CmdListQuotes.java
@@ -1,0 +1,176 @@
+package com.mcmoddev.mmdbot.modules.commands.server.quotes;
+
+import com.jagrosh.jdautilities.command.Command;
+import com.jagrosh.jdautilities.command.CommandEvent;
+import com.mcmoddev.mmdbot.core.Utils;
+import com.mcmoddev.mmdbot.utilities.quotes.Quote;
+import com.mcmoddev.mmdbot.utilities.quotes.QuoteList;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.Emoji;
+import net.dv8tion.jda.api.entities.TextChannel;
+import net.dv8tion.jda.api.events.interaction.ButtonClickEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.interactions.components.Button;
+import net.dv8tion.jda.api.interactions.components.Component;
+import net.dv8tion.jda.api.requests.restaction.MessageAction;
+import org.jetbrains.annotations.NotNull;
+
+import java.awt.Color;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+
+/**
+ * Retrieve all quotes from the database.
+ * Allows an int argument, otherwise starts from 0.
+ * The int represents the first quote to start with, and will increase from there.
+ *
+ * Uses pagination and Interaction buttons.
+ * Implementation shamelessly stolen from willbl
+ *
+ * Possible forms:
+ *      !quotes
+ *      !quotes 155
+ *
+ * Can be used by anyone.
+ *
+ *
+ * @author Curle
+ */
+public class CmdListQuotes extends Command {
+
+    private static final int QUOTE_PER_PAGE = 10;
+
+    /**
+     * Create the command.
+     * Sets all the usual flags.
+     */
+    public CmdListQuotes() {
+        super();
+        name = "listquotes";
+        aliases = new String[] { "quotes", "list-quotes", "quoteslist" };
+        help = "Get all quotes. Specify a starting number if you like, otherwise starts from 0.";
+    }
+
+
+    @Override
+    protected void execute(final CommandEvent event) {
+        if (!Utils.checkCommand(this, event))
+            return;
+
+        final TextChannel channel = event.getTextChannel();
+        String argsFull = event.getArgs();
+        String[] args = argsFull.split(" ");
+
+        int start = 0;
+        if(args.length > 1) {
+            start = Integer.parseInt(args[0]);
+        }
+
+        MessageAction sentMessage = event.getChannel().sendMessageEmbeds(getQuotes(start).build());
+
+        Component[] buttons = createButtons(start);
+        if (buttons.length > 0)
+            sentMessage.setActionRow(buttons);
+
+        sentMessage.queue();
+
+    }
+
+    /**
+     * Create the row of Component interaction buttons.
+     *
+     * Currently, this just creates a left and right arrow.
+     * Left arrow scrolls back a page. Right arrow scrolls forward a page.
+     * @param start The quote number at the start of the current page.
+     * @return A row of buttons to go back and forth by one page in a quote list.
+     */
+    private static Component[] createButtons(int start) {
+        List<Component> components = new ArrayList<>();
+        if (start != 0) {
+            components.add(Button.secondary(ButtonListener.BUTTON_ID_PREFIX + "-" + start + "-prev", Emoji.fromUnicode("◀️")));
+        }
+        if (start + QUOTE_PER_PAGE < QuoteList.getQuoteSlot()) {
+            components.add(Button.primary(ButtonListener.BUTTON_ID_PREFIX + "-" + start + "-next", Emoji.fromUnicode("▶️")));
+        }
+        return components.toArray(new Component[0]);
+    }
+
+    /**
+     * Gather a page of quotes, as an embed.
+     *
+     * @param start The quote number at the start of the current page.
+     * @return An EmbedBuilder which is ready to be sent.
+     */
+    private static EmbedBuilder getQuotes(int start) {
+        // Build the list in a StringBuilder.
+        StringBuilder str = new StringBuilder();
+
+        // From the specified starting point until the end of the page..
+        for (int x = start; x < start + QUOTE_PER_PAGE; x++) {
+            // But stop early if we hit the end of the list,
+            if (x >= QuoteList.getQuoteSlot())
+                break;
+
+            // Get the current Quote
+            Quote fetchedQuote = QuoteList.getQuote(x);
+
+            // Put it in the description.
+            // message - author
+            str.append(fetchedQuote == null ? "Quote does not exist." :
+                fetchedQuote.getQuoteText() + " - " + fetchedQuote.getQuotee().resolveReference());
+
+            str.append("\n");
+        }
+
+        // We have to make sure that this doesn't crash if we list a fresh bot.
+        if (str.length() == 0)
+            return new EmbedBuilder()
+                .setColor(Color.GREEN)
+                .setDescription("There are no quotes loaded currently.")
+                .setTimestamp(Instant.now());
+        else
+            return new EmbedBuilder()
+                .setColor(Color.GREEN)
+                .setTitle("Quote Page " + ((start / QUOTE_PER_PAGE) + 1))
+                .setDescription(str.toString())
+                .setTimestamp(Instant.now());
+
+    }
+
+    public static class ButtonListener extends ListenerAdapter {
+        private static final String BUTTON_ID_PREFIX = "quotelist";
+
+        @Override
+        public void onButtonClick(@NotNull final ButtonClickEvent event) {
+            var button = event.getButton();
+            if (button == null || button.getId() == null) {
+                return;
+            }
+
+            String[] idParts = button.getId().split("-");
+            if (idParts.length != 3) {
+                return;
+            }
+
+            if (!idParts[0].equals(BUTTON_ID_PREFIX)) {
+                return;
+            }
+
+            int current = Integer.parseInt(idParts[1]);
+
+            if (idParts[2].equals("next")) {
+                event
+                    .editMessageEmbeds(getQuotes(current + QUOTE_PER_PAGE).build())
+                    .setActionRow(createButtons(current + QUOTE_PER_PAGE))
+                    .queue();
+            } else if (idParts[2].equals("prev")) {
+                event
+                    .editMessageEmbeds(getQuotes(current - QUOTE_PER_PAGE).build())
+                    .setActionRow(createButtons(current - QUOTE_PER_PAGE))
+                    .queue();
+            }
+        }
+    }
+}

--- a/src/main/java/com/mcmoddev/mmdbot/modules/commands/server/quotes/CmdListQuotes.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/commands/server/quotes/CmdListQuotes.java
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ * https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
  */
 package com.mcmoddev.mmdbot.modules.commands.server.quotes;
 

--- a/src/main/java/com/mcmoddev/mmdbot/utilities/Utils.java
+++ b/src/main/java/com/mcmoddev/mmdbot/utilities/Utils.java
@@ -103,7 +103,7 @@ public final class Utils {
      * @return The difference between the two times.
      */
     public static String getTimeDifference(final LocalDateTime fromTime, final LocalDateTime toTime) {
-        return getTimeDifference(fromTime, toTime, ChronoUnit.YEARS, ChronoUnit.MONTHS, ChronoUnit.DAYS);
+        return getTimeDifference(fromTime, toTime, ChronoUnit.YEARS, ChronoUnit.MONTHS, ChronoUnit.DAYS, ChronoUnit.HOURS);
     }
 
     /**
@@ -127,6 +127,12 @@ public final class Utils {
                     - 1) : unitName));
             }
         }
+
+        if (joiner.length() == 0) {
+            // No valid representation found.
+            joiner.add("a very short amount of time.");
+        }
+
         return joiner.toString();
     }
 

--- a/src/main/java/com/mcmoddev/mmdbot/utilities/Utils.java
+++ b/src/main/java/com/mcmoddev/mmdbot/utilities/Utils.java
@@ -38,8 +38,8 @@ import net.dv8tion.jda.api.entities.TextChannel;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Objects;
@@ -85,14 +85,14 @@ public final class Utils {
     }
 
     /**
-     * Borrowed from Darkhax's BotBase, all credit for the below methods go to him.
-     * The Bot Base repo and code is now deleted if you need it for reference Proxy has a copy. Dark may also have one.
+     * Get the OffsetDateTime from an Instant value, relative to UTC+0 / GMT+0.
+     * Overtakes the last system which used LocalDateTime and caused issues with the database.
      *
      * @param instant the instant
-     * @return LocalDateTime. local time
+     * @return OffsetDateTime. Offset from UTC+0.
      */
-    public static LocalDateTime getLocalTime(final Instant instant) {
-        return LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
+    public static OffsetDateTime getTimeFromUTC(final Instant instant) {
+        return OffsetDateTime.ofInstant(instant, ZoneOffset.UTC);
     }
 
     /**
@@ -102,7 +102,7 @@ public final class Utils {
      * @param toTime   The end time.
      * @return The difference between the two times.
      */
-    public static String getTimeDifference(final LocalDateTime fromTime, final LocalDateTime toTime) {
+    public static String getTimeDifference(final OffsetDateTime fromTime, final OffsetDateTime toTime) {
         return getTimeDifference(fromTime, toTime, ChronoUnit.YEARS, ChronoUnit.MONTHS, ChronoUnit.DAYS, ChronoUnit.HOURS);
     }
 
@@ -114,10 +114,10 @@ public final class Utils {
      * @param units    the units
      * @return The difference between the two times.
      */
-    public static String getTimeDifference(final LocalDateTime fromTime, final LocalDateTime toTime,
+    public static String getTimeDifference(final OffsetDateTime fromTime, final OffsetDateTime toTime,
                                            final ChronoUnit... units) {
         final var joiner = new StringJoiner(", ");
-        var temp = LocalDateTime.from(fromTime);
+        var temp = OffsetDateTime.from(fromTime);
         for (final ChronoUnit unit : units) {
             final long time = temp.until(toTime, unit);
             if (time > 0) {

--- a/src/main/java/com/mcmoddev/mmdbot/utilities/Utils.java
+++ b/src/main/java/com/mcmoddev/mmdbot/utilities/Utils.java
@@ -86,7 +86,7 @@ public final class Utils {
 
     /**
      * Get the OffsetDateTime from an Instant value, relative to UTC+0 / GMT+0.
-     * Overtakes the last system which used LocalDateTime and caused issues with the database.
+     * Overtakes the last system which used LocalDateTime which was unpredictable and caused confusion among developers.
      *
      * @param instant the instant
      * @return OffsetDateTime. Offset from UTC+0.

--- a/src/main/java/com/mcmoddev/mmdbot/utilities/quotes/IQuote.java
+++ b/src/main/java/com/mcmoddev/mmdbot/utilities/quotes/IQuote.java
@@ -83,4 +83,10 @@ public interface IQuote {
      */
     MessageEmbed getQuoteMessage();
 
+    /**
+     * Get the closest text representation of the thing being quoted.
+     * @return Depends on the subclass.
+     */
+    String getQuoteText();
+
 }

--- a/src/main/java/com/mcmoddev/mmdbot/utilities/quotes/IQuote.java
+++ b/src/main/java/com/mcmoddev/mmdbot/utilities/quotes/IQuote.java
@@ -85,6 +85,7 @@ public interface IQuote {
 
     /**
      * Get the closest text representation of the thing being quoted.
+     *
      * @return Depends on the subclass.
      */
     String getQuoteText();

--- a/src/main/java/com/mcmoddev/mmdbot/utilities/quotes/NullQuote.java
+++ b/src/main/java/com/mcmoddev/mmdbot/utilities/quotes/NullQuote.java
@@ -34,6 +34,11 @@ public final class NullQuote extends Quote {
         return QuoteList.getQuoteNotPresent();
     }
 
+    @Override
+    public String getQuoteText() {
+        return "Quote not found.";
+    }
+
     /**
      * Create a new NullQuote.
      */

--- a/src/main/java/com/mcmoddev/mmdbot/utilities/quotes/QuoteList.java
+++ b/src/main/java/com/mcmoddev/mmdbot/utilities/quotes/QuoteList.java
@@ -93,7 +93,6 @@ public final class QuoteList {
      * The message used for when quotes are null, or do not exist.
      */
     private static final MessageEmbed QUOTE_NOT_PRESENT = new EmbedBuilder()
-        .setAuthor(References.NAME, MMDBot.getInstance().getSelfUser().getAvatarUrl())
         .setTitle("Quote")
         .setColor(Color.GREEN)
         .addField("Warning", "Specified quote does not exist.", false)

--- a/src/main/java/com/mcmoddev/mmdbot/utilities/quotes/StringQuote.java
+++ b/src/main/java/com/mcmoddev/mmdbot/utilities/quotes/StringQuote.java
@@ -66,7 +66,6 @@ public final class StringQuote extends Quote {
     @Override
     public MessageEmbed getQuoteMessage() {
         EmbedBuilder builder = new EmbedBuilder();
-        builder.setAuthor(References.NAME, MMDBot.getInstance().getSelfUser().getAvatarUrl());
         builder.setTitle("Quote " + this.getID());
         builder.setColor(Color.GREEN);
         builder.addField("Content", this.getData(), false);
@@ -75,8 +74,16 @@ public final class StringQuote extends Quote {
         UserReference quotee = this.getQuotee();
         switch (quotee.getReferenceType()) {
             case SNOWFLAKE:
-                UserById user = new UserById(quotee.getSnowflakeData());
-                builder.addField("Author", user.getAsMention(), false);
+                // Try to find the user's data in a server
+                User user = MMDBot.getInstance().getUserById(quotee.getSnowflakeData());
+                // If we have it...
+                if (user != null) {
+                    // Use it
+                    builder.addField("Author", user.getAsTag(), false);
+                } else {
+                    // Otherwise, fall back to the snowflake.
+                    builder.addField("Author", Long.toString(quotee.getSnowflakeData()), false);
+                }
                 break;
             case STRING:
                 builder.addField("Author", quotee.getStringData(), false);

--- a/src/main/java/com/mcmoddev/mmdbot/utilities/quotes/StringQuote.java
+++ b/src/main/java/com/mcmoddev/mmdbot/utilities/quotes/StringQuote.java
@@ -20,12 +20,8 @@
  */
 package com.mcmoddev.mmdbot.utilities.quotes;
 
-import com.mcmoddev.mmdbot.MMDBot;
-import com.mcmoddev.mmdbot.core.References;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.MessageEmbed;
-import net.dv8tion.jda.api.entities.User;
-import net.dv8tion.jda.internal.entities.UserById;
 
 import java.awt.Color;
 import java.time.Instant;
@@ -65,63 +61,19 @@ public final class StringQuote extends Quote {
 
     @Override
     public MessageEmbed getQuoteMessage() {
-        EmbedBuilder builder = new EmbedBuilder();
-        builder.setTitle("Quote " + this.getID());
-        builder.setColor(Color.GREEN);
-        builder.addField("Content", this.getData(), false);
+        return new EmbedBuilder()
+            .setTitle("Quote " + this.getID())
+            .setColor(Color.GREEN)
+            .addField("Content", this.getData(), false)
+            .addField("Author", quotee.resolveReference(), false)
+            .setFooter("Quoted by " + creator.resolveReference())
+            .setTimestamp(Instant.now())
+            .build();
+    }
 
-        // Resolve the person being quoted.
-        UserReference quotee = this.getQuotee();
-        switch (quotee.getReferenceType()) {
-            case SNOWFLAKE:
-                // Try to find the user's data in a server
-                User user = MMDBot.getInstance().getUserById(quotee.getSnowflakeData());
-                // If we have it...
-                if (user != null) {
-                    // Use it
-                    builder.addField("Author", user.getAsTag(), false);
-                } else {
-                    // Otherwise, fall back to the snowflake.
-                    builder.addField("Author", Long.toString(quotee.getSnowflakeData()), false);
-                }
-                break;
-            case STRING:
-                builder.addField("Author", quotee.getStringData(), false);
-                break;
-
-            case ANONYMOUS: // Intentional fallthrough.
-            default:
-                builder.addField("Author", quotee.getAnonymousData(), false);
-                break;
-        }
-
-        // Resolve the person that made the quote..
-        UserReference author = this.getQuoteAuthor();
-        switch (author.getReferenceType()) {
-            case SNOWFLAKE:
-                // Try to find the user's data in a server
-                User user = MMDBot.getInstance().getUserById(author.getSnowflakeData());
-                // If we have it...
-                if (user != null) {
-                    // Use it
-                    builder.setFooter("Quoted by " + user.getAsTag());
-                } else {
-                    // Otherwise, fall back to the snowflake.
-                    builder.setFooter("Quoted by " + author.getSnowflakeData());
-                }
-                break;
-            case STRING:
-                builder.setFooter("Quoted by " + author.getStringData());
-                break;
-
-            case ANONYMOUS: // Intentional fallthrough.
-            default:
-                builder.setFooter("Quoted by " + author.getAnonymousData());
-                break;
-        }
-
-        builder.setTimestamp(Instant.now());
-        return builder.build();
+    @Override
+    public String getQuoteText() {
+        return data;
     }
 
     /**

--- a/src/main/java/com/mcmoddev/mmdbot/utilities/quotes/UserReference.java
+++ b/src/main/java/com/mcmoddev/mmdbot/utilities/quotes/UserReference.java
@@ -20,6 +20,9 @@
  */
 package com.mcmoddev.mmdbot.utilities.quotes;
 
+import com.mcmoddev.mmdbot.MMDBot;
+import net.dv8tion.jda.api.entities.User;
+
 /**
  * The information containing "who" or "what" a quote is referencing.
  * Can be for either the thing being quoted, or the thing that created the quote.
@@ -124,6 +127,32 @@ public final class UserReference {
      */
     public String getAnonymousData() {
         return anonymousData;
+    }
+
+    /**
+     * Convert the Reference to its closest String representation.
+     * @return A mention if the user is a Snowflake and is in the current guild,
+     *           An ID if the user is a snowflake and is not in the current guild,
+     *           A message if the user is anonymous or String.
+     */
+    public String resolveReference() {
+        switch (getReferenceType()) {
+            case SNOWFLAKE:
+                // Try to find the user's data in a server
+                User user = MMDBot.getInstance().getUserById(getSnowflakeData());
+                // If we have it...
+                if (user != null) {
+                    return user.getAsTag();
+                } else {
+                    return String.valueOf(getSnowflakeData());
+                }
+            case STRING:
+                return getStringData();
+
+            case ANONYMOUS: // Intentional fallthrough.
+            default:
+                return getAnonymousData();
+        }
     }
 
     /**

--- a/src/main/java/com/mcmoddev/mmdbot/utilities/quotes/UserReference.java
+++ b/src/main/java/com/mcmoddev/mmdbot/utilities/quotes/UserReference.java
@@ -132,8 +132,8 @@ public final class UserReference {
     /**
      * Convert the Reference to its closest String representation.
      * @return A mention if the user is a Snowflake and is in the current guild,
-     *           An ID if the user is a snowflake and is not in the current guild,
-     *           A message if the user is anonymous or String.
+     * An ID if the user is a snowflake and is not in the current guild,
+     * A message if the user is anonymous or String.
      */
     public String resolveReference() {
         switch (getReferenceType()) {


### PR DESCRIPTION
Notable additions:
- Fully paginaged quote list.

Bugs fixed:

- Quotes with too many arguments are allowed.
- Quote messages that don't end with a `"` are allowed.
- Random quotes don't pick the most recent quote.
- Random quotes can choose an invalid quote.
- Snowflake IDs used for author attribution in a quote can lead to strangeness:
![image](https://user-images.githubusercontent.com/42079760/128793560-d080eb64-1964-427e-81cd-ec9d48de6c60.png)

- Utils#timeDifference can return no text if the amount of time is unrepresentable.

Other miscellaneous changes:

- "MMDBot" author attribution removed from Quote embeds.
- All time references changed to use UTC+0 rather than the local timezone of the bot.

