### PR TITLE
Make tricks marginally better

### DIFF
--- a/src/main/java/com/mcmoddev/mmdbot/modules/commands/CommandModule.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/commands/CommandModule.java
@@ -119,6 +119,7 @@ public class CommandModule {
             if (MMDBot.getConfig().isCommandModuleEnabled()) {
                 MMDBot.getInstance().addEventListener(commandClient);
                 MMDBot.getInstance().addEventListener(CmdMappings.ButtonListener.INSTANCE);
+                MMDBot.getInstance().addEventListener(new CmdListTricks.ButtonListener());
                 MMDBot.LOGGER.warn("Command module enabled and loaded.");
             } else {
                 MMDBot.LOGGER.warn("Command module disabled via config, commands will not work at this time!");

--- a/src/main/java/com/mcmoddev/mmdbot/modules/commands/server/tricks/CmdAddTrick.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/commands/server/tricks/CmdAddTrick.java
@@ -2,6 +2,7 @@ package com.mcmoddev.mmdbot.modules.commands.server.tricks;
 
 import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
+import com.mcmoddev.mmdbot.MMDBot;
 import com.mcmoddev.mmdbot.core.Utils;
 import com.mcmoddev.mmdbot.utilities.tricks.Tricks;
 
@@ -38,8 +39,13 @@ public final class CmdAddTrick extends Command {
         String args = event.getArgs();
         int firstSpace = args.indexOf(" ");
 
-        Tricks.addTrick(Tricks.getTrickType(args.substring(0, firstSpace))
-            .createFromArgs(args.substring(firstSpace + 1)));
-        channel.sendMessage("Added trick!").queue();
+        try {
+            Tricks.addTrick(Tricks.getTrickType(args.substring(0, firstSpace))
+                .createFromArgs(args.substring(firstSpace + 1)));
+            channel.sendMessage("Added trick!").queue();
+        } catch (IllegalArgumentException e) {
+            channel.sendMessage("A command with that name already exists!").queue();
+            MMDBot.LOGGER.warn("Failure adding trick: {}", e.getMessage());
+        }
     }
 }

--- a/src/main/java/com/mcmoddev/mmdbot/modules/commands/server/tricks/CmdListTricks.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/commands/server/tricks/CmdListTricks.java
@@ -37,10 +37,10 @@ public final class CmdListTricks extends Command {
         final var channel = event.getTextChannel();
 
         builder
+            .setTitle("Tricks")
             .setDescription(Tricks.getTricks()
                 .stream()
-                .map(it -> it.getNames().stream().reduce("", (a, b) -> String.join(a, " ", b)
-                    .trim()))
+                .map(it -> it.getNames().stream().reduce("", (a, b) -> String.join(a.isEmpty() ? a : a + " / ", b)))
                 .reduce("", (a, b) -> a + "\n" + b)
             );
 

--- a/src/main/java/com/mcmoddev/mmdbot/modules/commands/server/tricks/CmdListTricks.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/commands/server/tricks/CmdListTricks.java
@@ -40,7 +40,7 @@ public final class CmdListTricks extends Command {
             .setTitle("Tricks")
             .setDescription(Tricks.getTricks()
                 .stream()
-                .map(it -> it.getNames().stream().reduce("", (a, b) -> String.join(a.isEmpty() ? a : a + " / ", b)))
+                .map(it -> it.getNames().stream().reduce("", (a, b) -> (a.isEmpty() ? a : a + " / ") + b))
                 .reduce("", (a, b) -> a + "\n" + b)
             );
 

--- a/src/main/java/com/mcmoddev/mmdbot/modules/commands/server/tricks/CmdListTricks.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/commands/server/tricks/CmdListTricks.java
@@ -5,6 +5,16 @@ import com.jagrosh.jdautilities.command.CommandEvent;
 import com.mcmoddev.mmdbot.core.Utils;
 import com.mcmoddev.mmdbot.utilities.tricks.Tricks;
 import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.Emoji;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.events.interaction.ButtonClickEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.interactions.components.Button;
+import net.dv8tion.jda.api.interactions.components.Component;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author williambl
@@ -12,6 +22,8 @@ import net.dv8tion.jda.api.EmbedBuilder;
  * The type Cmd list tricks.
  */
 public final class CmdListTricks extends Command {
+
+    private static final int TRICKS_PER_PAGE = 10;
 
     /**
      * Instantiates a new Cmd list tricks.
@@ -33,21 +45,74 @@ public final class CmdListTricks extends Command {
         if (!Utils.checkCommand(this, event)) {
             return;
         }
-        final var builder = new EmbedBuilder();
         final var channel = event.getTextChannel();
-
-        builder
-            .setTitle("Tricks")
-            .setDescription(Tricks.getTricks()
-                .stream()
-                .map(it -> it.getNames().stream().reduce("", (a, b) -> (a.isEmpty() ? a : a + " / ") + b))
-                .reduce("", (a, b) -> a + "\n" + b)
-            );
+        final var builder = getTrickList(0);
 
         if (!builder.isEmpty()) {
-            channel.sendMessageEmbeds(builder.build()).queue();
+            var message = channel.sendMessageEmbeds(builder);
+            Component[] buttons = createActionRow(0);
+            if (buttons.length > 0) {
+                message = message.setActionRow(buttons);
+            }
+            message.queue();
         } else {
             channel.sendMessage("No tricks currently exist!").queue();
+        }
+    }
+
+    private static MessageEmbed getTrickList(int from) {
+        return new EmbedBuilder()
+            .setTitle("Tricks")
+            .setDescription(Tricks.getTricks()
+                .subList(from, from+TRICKS_PER_PAGE)
+                .stream()
+                .map(it -> it.getNames().stream().reduce("", (a, b) -> (a.isEmpty() ? a : a + " / ") + b))
+                .reduce("", (a, b) -> a + "\n" + b))
+            .build();
+    }
+
+    private static Component[] createActionRow(int lowestTrickIndex) {
+        List<Component> components = new ArrayList<>();
+        if (lowestTrickIndex != 0) {
+            components.add(Button.secondary(ButtonListener.BUTTON_ID_PREFIX+"-"+lowestTrickIndex+"-prev", Emoji.fromUnicode("◀️")));
+        }
+        if (lowestTrickIndex+TRICKS_PER_PAGE < Tricks.getTricks().size()) {
+            components.add(Button.primary(ButtonListener.BUTTON_ID_PREFIX + "-" + lowestTrickIndex + "-next", Emoji.fromUnicode("▶️")));
+        }
+        return components.toArray(new Component[0]);
+    }
+
+    public static class ButtonListener extends ListenerAdapter {
+        private static final String BUTTON_ID_PREFIX = "tricklist";
+        @Override
+        public void onButtonClick(@NotNull final ButtonClickEvent event) {
+            var button = event.getButton();
+            if (button == null || button.getId() == null) {
+                return;
+            }
+
+            String[] idParts = button.getId().split("-");
+            if (idParts.length != 3) {
+                return;
+            }
+
+            if (!idParts[0].equals(BUTTON_ID_PREFIX)) {
+                return;
+            }
+
+            int current = Integer.parseInt(idParts[1]);
+
+            if (idParts[2].equals("next")) {
+                event
+                    .editMessageEmbeds(List.of(getTrickList(current+TRICKS_PER_PAGE)))
+                    .setActionRow(createActionRow(current+TRICKS_PER_PAGE))
+                    .queue();
+            } else if (idParts[2].equals("prev")) {
+                event
+                    .editMessageEmbeds(List.of(getTrickList(current-TRICKS_PER_PAGE)))
+                    .setActionRow(createActionRow(current-TRICKS_PER_PAGE))
+                    .queue();
+            }
         }
     }
 }

--- a/src/main/java/com/mcmoddev/mmdbot/utilities/tricks/EmbedTrick.java
+++ b/src/main/java/com/mcmoddev/mmdbot/utilities/tricks/EmbedTrick.java
@@ -8,6 +8,7 @@ import net.dv8tion.jda.api.entities.MessageEmbed;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 /**
  * The type Embed trick.
@@ -84,7 +85,7 @@ public class EmbedTrick implements Trick {
         for (MessageEmbed.Field field : getFields()) {
             builder.addField(field);
         }
-        return new MessageBuilder(builder.build()).build();
+        return new MessageBuilder(builder.build()).setAllowedMentions(Set.of(Message.MentionType.CHANNEL, Message.MentionType.EMOTE)).build();
     }
 
     /**

--- a/src/main/java/com/mcmoddev/mmdbot/utilities/tricks/StringTrick.java
+++ b/src/main/java/com/mcmoddev/mmdbot/utilities/tricks/StringTrick.java
@@ -53,7 +53,7 @@ public class StringTrick implements Trick {
      */
     @Override
     public Message getMessage(final String[] args) {
-        return new MessageBuilder(getBody()).build();
+        return new MessageBuilder(String.format(getBody(), (Object[]) args)).build();
     }
 
     /**

--- a/src/main/java/com/mcmoddev/mmdbot/utilities/tricks/StringTrick.java
+++ b/src/main/java/com/mcmoddev/mmdbot/utilities/tricks/StringTrick.java
@@ -6,6 +6,7 @@ import net.dv8tion.jda.api.entities.Message;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 /**
  * The type String trick.
@@ -53,7 +54,7 @@ public class StringTrick implements Trick {
      */
     @Override
     public Message getMessage(final String[] args) {
-        return new MessageBuilder(String.format(getBody(), (Object[]) args)).build();
+        return new MessageBuilder(String.format(getBody(), (Object[]) args)).setAllowedMentions(Set.of(Message.MentionType.CHANNEL, Message.MentionType.EMOTE)).build();
     }
 
     /**

--- a/src/main/java/com/mcmoddev/mmdbot/utilities/tricks/Tricks.java
+++ b/src/main/java/com/mcmoddev/mmdbot/utilities/tricks/Tricks.java
@@ -7,6 +7,7 @@ import com.google.gson.TypeAdapterFactory;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import com.jagrosh.jdautilities.command.Command;
 import com.mcmoddev.mmdbot.MMDBot;
 import com.mcmoddev.mmdbot.modules.commands.CommandModule;
 import com.mcmoddev.mmdbot.modules.commands.server.tricks.CmdRunTrick;
@@ -130,13 +131,17 @@ public final class Tricks {
     }
 
     /**
-     * Add trick.
+     * Add a trick.
      *
-     * @param trick the trick
+     * @param trick the trick to add.
+     *
+     * @throws IllegalArgumentException propogated from
+     * {@link com.jagrosh.jdautilities.command.CommandClient#addCommand(Command)} if a command with the name or alias
+     * of the given trick already exists.
      */
     public static void addTrick(final Trick trick) {
-        getTricks().add(trick);
         CommandModule.getCommandClient().addCommand(new CmdRunTrick(trick));
+        getTricks().add(trick);
         write();
     }
 


### PR DESCRIPTION
 - adds string formatting to string tricks, so you can do, e.g. "!trick arg arg2", where trick is defined as `%s is %s`, and it will say `arg is arg2`
 - fixes trick aliases being smooshed together in !listtricks
 - disallows tricks from being added if a command with the same name exists
 - stops tricks from being able to ping people
 - adds pagination to trick list