### PR TITLE
Fixes and new embeds in deletion messages

### DIFF
--- a/src/main/java/com/mcmoddev/mmdbot/modules/logging/users/EventNicknameChanged.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/logging/users/EventNicknameChanged.java
@@ -71,7 +71,7 @@ public final class EventNicknameChanged extends ListenerAdapter {
                     if (entry.getTargetIdLong() != target.getIdLong()) {
                         MMDBot.LOGGER.warn(MMDMarkers.EVENTS, "Inconsistency between target of retrieved audit log "
                                 + "entry and actual nickname event target: retrieved is {}, but target is {}",
-                            target, entry.getUser());
+                            entry.getUser(), target);
                     } else if (entry.getUser() != null) {
                         final var editor = entry.getUser();
                         embed.addField("Nickname Editor:", editor.getAsMention() + " ("

--- a/src/main/java/com/mcmoddev/mmdbot/modules/logging/users/EventRoleAdded.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/logging/users/EventRoleAdded.java
@@ -109,7 +109,7 @@ public final class EventRoleAdded extends ListenerAdapter {
                         true);
                     if (entry.getTargetIdLong() != target.getIdLong()) {
                         LOGGER.warn(MMDMarkers.EVENTS, "Inconsistency between target of retrieved audit log entry and actual "
-                            + "role event target: retrieved is {}, but target is {}", target, entry.getUser());
+                            + "role event target: retrieved is {}, but target is {}", entry.getUser(), target);
                     } else if (entry.getUser() != null) {
                         final var editor = entry.getUser();
                         embed.addField("Editor:", editor.getAsMention() + " (" + editor.getId() + ")",

--- a/src/main/java/com/mcmoddev/mmdbot/modules/logging/users/EventRoleRemoved.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/logging/users/EventRoleRemoved.java
@@ -80,7 +80,7 @@ public final class EventRoleRemoved extends ListenerAdapter {
                         true);
                     if (entry.getTargetIdLong() != target.getIdLong()) {
                         LOGGER.warn(MMDMarkers.EVENTS, "Inconsistency between target of retrieved audit log entry and actual "
-                            + "role event target: retrieved is {}, but target is {}", target, entry.getUser());
+                            + "role event target: retrieved is {}, but target is {}", entry.getUser(), target);
                     } else if (entry.getUser() != null) {
                         final var editor = entry.getUser();
                         embed.addField("Editor:", editor.getAsMention() + " (" + editor.getId() + ")",

--- a/src/main/java/com/mcmoddev/mmdbot/modules/logging/users/EventUserLeft.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/logging/users/EventUserLeft.java
@@ -122,8 +122,8 @@ public final class EventUserLeft extends ListenerAdapter {
                         .filter(message -> message.getAuthor().equals(leavingUser))
                         .forEach(message -> {
                         LOGGER.info(MMDMarkers.REQUESTS, "Removed request from {} (current leave deletion of "
-                                + "{} hour(s), sent {}) because they left the server",
-                            leavingUser, message.getTimeCreated(), deletionTime);
+                                + "{} hour(s), message sent on {}) because they left the server",
+                            leavingUser, deletionTime, message.getTimeCreated());
 
                         final var logChannel = guild.getTextChannelById(getConfig()
                             .getChannel("events.requests_deletion"));

--- a/src/main/java/com/mcmoddev/mmdbot/modules/logging/users/EventUserLeft.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/logging/users/EventUserLeft.java
@@ -116,10 +116,11 @@ public final class EventUserLeft extends ListenerAdapter {
         if (requestsChannel != null && deletionTime > 0) {
             final OffsetDateTime now = OffsetDateTime.now().minusHours(deletionTime);
             requestsChannel.getIterableHistory()
-                .takeWhileAsync(message -> message.getTimeCreated().isAfter(now)
-                    && message.getAuthor().equals(leavingUser))
+                .takeWhileAsync(message -> message.getTimeCreated().isAfter(now))
                 .thenAccept(messages ->
-                    messages.forEach(message -> {
+                    messages.stream()
+                        .filter(message -> message.getAuthor().equals(leavingUser))
+                        .forEach(message -> {
                         LOGGER.info(MMDMarkers.REQUESTS, "Removed request from {} (current leave deletion of "
                                 + "{} hour(s), sent {}) because they left the server",
                             leavingUser, message.getTimeCreated(), deletionTime);

--- a/src/main/java/com/mcmoddev/mmdbot/modules/logging/users/EventUserLeft.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/logging/users/EventUserLeft.java
@@ -32,6 +32,7 @@ import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberRemoveEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.utils.TimeFormat;
 
 import java.awt.Color;
 import java.time.Instant;
@@ -117,10 +118,9 @@ public final class EventUserLeft extends ListenerAdapter {
             final OffsetDateTime now = OffsetDateTime.now().minusHours(deletionTime);
             requestsChannel.getIterableHistory()
                 .takeWhileAsync(message -> message.getTimeCreated().isAfter(now))
-                .thenAccept(messages ->
-                    messages.stream()
-                        .filter(message -> message.getAuthor().equals(leavingUser))
-                        .forEach(message -> {
+                .thenAccept(messages -> messages.stream()
+                    .filter(message -> message.getAuthor().equals(leavingUser))
+                    .forEach(message -> {
                         LOGGER.info(MMDMarkers.REQUESTS, "Removed request from {} (current leave deletion of "
                                 + "{} hour(s), message sent on {}) because they left the server",
                             leavingUser, deletionTime, message.getTimeCreated());
@@ -128,9 +128,21 @@ public final class EventUserLeft extends ListenerAdapter {
                         final var logChannel = guild.getTextChannelById(getConfig()
                             .getChannel("events.requests_deletion"));
                         if (logChannel != null) {
-                            logChannel.sendMessage(String.format("Auto-deleted request from %s (%s;`%s`) "
-                                        + "due to leaving server: %n%s", leavingUser.getAsMention(), leavingUser.getAsTag(),
-                                    leavingUser.getId(), message.getContentRaw()))
+                            EmbedBuilder builder = new EmbedBuilder();
+                            builder.setTitle("Automatic request deletion");
+                            builder.setAuthor(leavingUser.getAsTag(), leavingUser.getEffectiveAvatarUrl());
+                            builder.appendDescription("Deleted request from ")
+                                .appendDescription(leavingUser.getAsMention())
+                                .appendDescription(" as the user left the user.");
+                            builder.addField("Message Creation Time",
+                                TimeFormat.DATE_TIME_SHORT.format(message.getTimeCreated()), true);
+                            builder.addField("Auto-Deletion on Leave Duration", deletionTime + " hour(s)", true);
+                            builder.setTimestamp(Instant.now());
+                            builder.setColor(Color.PINK);
+                            builder.setFooter("User ID: " + leavingUser.getId());
+
+                            logChannel.sendMessage(message.getContentRaw())
+                                .setEmbeds(builder.build())
                                 .allowedMentions(Collections.emptySet())
                                 .queue();
                         }

--- a/src/main/java/com/mcmoddev/mmdbot/modules/logging/users/UserBanned.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/logging/users/UserBanned.java
@@ -81,7 +81,7 @@ public class UserBanned extends ListenerAdapter {
                     if (entry.getTargetIdLong() != target.getIdLong()) {
                         MMDBot.LOGGER.warn(MMDMarkers.EVENTS, "Inconsistency between target of retrieved audit log "
                                 + "entry and actual ban event target: retrieved is {}, but target is {}",
-                            target, entry.getUser());
+                            entry.getUser(), target);
                     } else if (entry.getUser() != null) {
                         final var editor = entry.getUser();
                         embed.setDescription("Banned By: " + editor.getName() + " (" + editor.getId() + ")");

--- a/src/main/java/com/mcmoddev/mmdbot/utilities/Utils.java
+++ b/src/main/java/com/mcmoddev/mmdbot/utilities/Utils.java
@@ -349,19 +349,14 @@ public final class Utils {
     }
 
     /**
-     * Calls the given consumer only if the channel with the given ID is present within the
-     * {@linkplain BotConfig#getGuildID() bot's guild}.
+     * Calls the given consumer only if the text channel with the given ID is known to the bot.
      *
      * @param channelID The channel ID
-     * @param consumer  The consumer of the channel
+     * @param consumer  The consumer of the text channel
+     * @see net.dv8tion.jda.api.JDA#getTextChannelById(long)
      */
     public static void getChannelIfPresent(final long channelID, final Consumer<TextChannel> consumer) {
-        final long guildID = getConfig().getGuildID();
-        final var guild = MMDBot.getInstance().getGuildById(guildID);
-        if (guild == null) {
-            return;
-        }
-        final var channel = guild.getTextChannelById(channelID);
+        final var channel = MMDBot.getInstance().getTextChannelById(channelID);
         if (channel != null) {
             consumer.accept(channel);
         }


### PR DESCRIPTION
_(note: still needs a bit of testing regarding the big changes)_

## Commits breakdown

### Big changes

- **Fix requests not being deleted when intermediate messages are present**
  For example, if user A posted a request, then user B posted a request, then user A left such that their request would be deleted, the request would not be deleted because the takeWhileAsync predicate would not match the request from user B (as it's not from the target user, user A).
  To fix this, the message filtering is moved to after the messages within the deletion period have been collected, then filtered for requests from the target user.

- **Improve auto-deletion message to use informational embed**
  This improves readability by distinctly separating the content of the deleted request with the information about the user and request.

- **Improve request deletion message to use informational embed**
  This improves readability by distinctly separating the content of the deleted request with the information about the user and request. The embed also includes the information on which moderators approved of the deletion (by reacting with a 'bad request' emote).

### Minor changes

- **Refactor auto-deletion code to ignore if message is already deleted**
- Some minor fixes about arguments in logging statements <sup>(damn you, past me /jk)</sup>
  - **Fix inverted arguments in log statement about audit inconsistency**
  - **Fix reversal of arguments in log statements**
- **Adjust Util#getChannelIfPresent to use JDA instead of the guild**
  This allows setting channels as output locations which aren't part of the home guild for the bot, as long as the channel is known to the bot/JDA.