### PR TITLE
Improve help command with embeds and pagination.

### DIFF
--- a/src/main/java/com/mcmoddev/mmdbot/modules/commands/CommandModule.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/commands/CommandModule.java
@@ -25,6 +25,7 @@ import com.jagrosh.jdautilities.command.CommandClient;
 import com.jagrosh.jdautilities.command.CommandClientBuilder;
 import com.mcmoddev.mmdbot.MMDBot;
 import com.mcmoddev.mmdbot.modules.commands.bot.info.CmdAbout;
+import com.mcmoddev.mmdbot.modules.commands.bot.info.CmdHelp;
 import com.mcmoddev.mmdbot.modules.commands.bot.info.CmdUptime;
 import com.mcmoddev.mmdbot.modules.commands.bot.management.CmdAvatar;
 import com.mcmoddev.mmdbot.modules.commands.bot.management.CmdRename;
@@ -88,6 +89,7 @@ public class CommandModule {
             .setOwnerId(MMDBot.getConfig().getOwnerID())
             .setPrefix(MMDBot.getConfig().getMainPrefix())
             .setAlternativePrefix(MMDBot.getConfig().getAlternativePrefix())
+            .setHelpConsumer(CmdHelp::execute)
             .addCommand(new CmdGuild())
             .addCommand(new CmdAbout())
             .addCommand(new CmdMe())
@@ -131,6 +133,7 @@ public class CommandModule {
             MMDBot.getInstance().addEventListener(CmdTranslateMappings.ButtonListener.INSTANCE);
             MMDBot.getInstance().addEventListener(new CmdListTricks.ButtonListener());
             MMDBot.getInstance().addEventListener(new CmdListQuotes.ButtonListener());
+            MMDBot.getInstance().addEventListener(new CmdHelp.ButtonListener());
             MMDBot.LOGGER.warn("Command module enabled and loaded.");
         } else {
             MMDBot.LOGGER.warn("Command module disabled via config, commands will not work at this time!");

--- a/src/main/java/com/mcmoddev/mmdbot/modules/commands/bot/info/CmdHelp.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/commands/bot/info/CmdHelp.java
@@ -1,8 +1,27 @@
+/*
+ * MMDBot - https://github.com/MinecraftModDevelopment/MMDBot
+ * Copyright (C) 2016-2021 <MMD - MinecraftModDevelopment>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ * https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ */
 package com.mcmoddev.mmdbot.modules.commands.bot.info;
 
 import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
-import com.jagrosh.jdautilities.command.SlashCommand;
 import com.mcmoddev.mmdbot.MMDBot;
 import com.mcmoddev.mmdbot.core.References;
 import com.mcmoddev.mmdbot.modules.commands.CommandModule;

--- a/src/main/java/com/mcmoddev/mmdbot/modules/commands/bot/info/CmdHelp.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/commands/bot/info/CmdHelp.java
@@ -93,7 +93,7 @@ public class CmdHelp {
                         embed.addField(commandList.get(i).getName(), commandList.get(i).getHelp(), true);
             }
 
-            embed.setFooter("Camelot").setTimestamp(Instant.now());
+            embed.setFooter(References.NAME).setTimestamp(Instant.now());
 
             return embed;
         }

--- a/src/main/java/com/mcmoddev/mmdbot/modules/commands/bot/info/CmdHelp.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/commands/bot/info/CmdHelp.java
@@ -1,0 +1,138 @@
+package com.mcmoddev.mmdbot.modules.commands.bot.info;
+
+import com.jagrosh.jdautilities.command.Command;
+import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.command.SlashCommand;
+import com.mcmoddev.mmdbot.MMDBot;
+import com.mcmoddev.mmdbot.core.References;
+import com.mcmoddev.mmdbot.modules.commands.CommandModule;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.Emoji;
+import net.dv8tion.jda.api.events.interaction.ButtonClickEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.interactions.components.Button;
+import net.dv8tion.jda.api.interactions.components.Component;
+import net.dv8tion.jda.api.requests.restaction.MessageAction;
+import org.jetbrains.annotations.NotNull;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This command doesn't use the normal syntax.
+ * Instead, it provides a single Consumer<CommandEvent> that the CommandClient can use.
+ *
+ * This should not be turned into a normal Command.
+ *
+ * @author Curle
+ */
+public class CmdHelp {
+
+        private static final int COMMANDS_PER_PAGE = 25;
+
+        /**
+         * Prepare the potential scrolling buttons for a help command,
+         *  and send the message with the proper embeds.
+         *
+         * See {@link #getHelpStartingAt(int)} for the implementation.
+         * @param e
+         */
+        public static void execute(CommandEvent e) {
+            MessageAction reply = e.getChannel().sendMessageEmbeds(getHelpStartingAt(0).build());
+            Component[] buttons = createScrollButtons(0);
+            if (buttons.length > 0)
+                reply.setActionRow(buttons);
+
+            reply.queue();
+        }
+
+        /**
+         * Create the row of Component interaction buttons.
+         * <p>
+         * Currently, this just creates a left and right arrow.
+         * Left arrow scrolls back a page. Right arrow scrolls forward a page.
+         *
+         * @param start The quote number at the start of the current page.
+         * @return A row of buttons to go back and forth by one page in a quote list.
+         */
+        private static Component[] createScrollButtons(int start) {
+            List<Component> components = new ArrayList<>();
+            if (start != 0) {
+                components.add(Button.secondary(ButtonListener.BUTTON_ID_PREFIX + "-" + start + "-prev",
+                    Emoji.fromUnicode("◀️")));
+            }
+            if (start + COMMANDS_PER_PAGE < CommandModule.getCommandClient().getCommands().size() + CommandModule.getCommandClient().getSlashCommands().size()) {
+                components.add(Button.primary(ButtonListener.BUTTON_ID_PREFIX + "-" + start + "-next",
+                    Emoji.fromUnicode("▶️")));
+            }
+            return components.toArray(new Component[0]);
+        }
+
+        /**
+         * Given a starting index, build an embed that we can display for users
+         *  to summarise all available commands.
+         * Intended to be used with pagination in the case of servers with LOTS of commands.
+         */
+        private static EmbedBuilder getHelpStartingAt(int index) {
+            EmbedBuilder embed = new EmbedBuilder();
+            embed.setAuthor(References.NAME, References.ISSUE_TRACKER, MMDBot.getInstance().getSelfUser().getAvatarUrl());
+            embed.setDescription("All registered commands:");
+
+            List<Command> commandList = CommandModule.getCommandClient().getCommands();
+            commandList.addAll(CommandModule.getCommandClient().getSlashCommands());
+
+            // Embeds have a 25 field limit. We need to make sure we don't exceed that.
+            if(commandList.size() < 25) {
+                for (Command c : commandList)
+                    embed.addField(c.getName(), c.getHelp(), true);
+            } else {
+                // Make sure we only go up to the limit.
+                for (int i = index; i < index + 25; i++)
+                    if (i < commandList.size())
+                        embed.addField(commandList.get(i).getName(), commandList.get(i).getHelp(), true);
+            }
+
+            embed.setFooter("Camelot").setTimestamp(Instant.now());
+
+            return embed;
+        }
+
+        public static class ButtonListener extends ListenerAdapter {
+            private static final String BUTTON_ID_PREFIX = "help";
+
+            @Override
+            public void onButtonClick(@NotNull final ButtonClickEvent event) {
+                var button = event.getButton();
+                if (button == null || button.getId() == null) {
+                    return;
+                }
+
+                String[] idParts = button.getId().split("-");
+                if (idParts.length != 3) {
+                    return;
+                }
+
+                if (!idParts[0].equals(BUTTON_ID_PREFIX)) {
+                    return;
+                }
+
+                int current = Integer.parseInt(idParts[1]);
+
+                if (idParts[2].equals("next")) {
+                    event
+                        .editMessageEmbeds(getHelpStartingAt(current + COMMANDS_PER_PAGE).build())
+                        .setActionRow(createScrollButtons(current + COMMANDS_PER_PAGE))
+                        .queue();
+                } else {
+                    if (idParts[2].equals("prev")) {
+                        event
+                            .editMessageEmbeds(getHelpStartingAt(current - COMMANDS_PER_PAGE).build())
+                            .setActionRow(createScrollButtons(current - COMMANDS_PER_PAGE))
+                            .queue();
+                    }
+                }
+            }
+        }
+    }
+


### PR DESCRIPTION
The current help command is in dire need of attention.
Primarily, it operates by sending a DM to the user that asked for help.

That is poor user interface in general, but it does it by just dumping a wall of text that is very hard to parse.

This PR changes the help system greatly, using an almost identical system to the existing pagination that i created for quotes.
It replies to the help request *in the same channel*, using an embed that looks not dissimilar from the following:
![image](https://user-images.githubusercontent.com/42079760/137570808-605a999d-067d-4d7f-bb60-fd1df7cf2ef3.png)

The scroll button at the bottom is only added if there are enough commands to warrant it, as seen here with the bot i was using to test this new feature:
![image](https://user-images.githubusercontent.com/42079760/137570864-5fa37861-1404-4931-8314-f57bee4c1c16.png)

There is the disadvantage of removing the command categorization, but as per my discussion with @ProxyNeko, this doesn't seem to be such a disadvantage due to the poor state of the categorization system anyway.

Regardless, this could be easily refactored in the future to reincorporate it.

From some mild testing, this feature seems to be just about as stable as the quote list command is is based on, so there shouldn't be many issues stemming from this.

Thanks.
