### PR TITLE
Implement targetted help command.

### DIFF
--- a/src/main/java/com/mcmoddev/mmdbot/modules/commands/CommandModule.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/commands/CommandModule.java
@@ -56,7 +56,6 @@ import com.mcmoddev.mmdbot.modules.commands.server.tricks.CmdListTricks;
 import com.mcmoddev.mmdbot.modules.commands.server.tricks.CmdRemoveTrick;
 import com.mcmoddev.mmdbot.utilities.tricks.Tricks;
 import me.shedaniel.linkie.Namespaces;
-import net.dv8tion.jda.internal.utils.Helpers;
 
 /**
  * This is the main class for setting up commands before they are loaded in by the bot,

--- a/src/main/java/com/mcmoddev/mmdbot/modules/commands/CommandModule.java
+++ b/src/main/java/com/mcmoddev/mmdbot/modules/commands/CommandModule.java
@@ -56,6 +56,7 @@ import com.mcmoddev.mmdbot.modules.commands.server.tricks.CmdListTricks;
 import com.mcmoddev.mmdbot.modules.commands.server.tricks.CmdRemoveTrick;
 import com.mcmoddev.mmdbot.utilities.tricks.Tricks;
 import me.shedaniel.linkie.Namespaces;
+import net.dv8tion.jda.internal.utils.Helpers;
 
 /**
  * This is the main class for setting up commands before they are loaded in by the bot,
@@ -89,7 +90,8 @@ public class CommandModule {
             .setOwnerId(MMDBot.getConfig().getOwnerID())
             .setPrefix(MMDBot.getConfig().getMainPrefix())
             .setAlternativePrefix(MMDBot.getConfig().getAlternativePrefix())
-            .setHelpConsumer(CmdHelp::execute)
+            .useHelpBuilder(false) // We want help to show as a command, so add it as one.
+            .addCommand(new CmdHelp())
             .addCommand(new CmdGuild())
             .addCommand(new CmdAbout())
             .addCommand(new CmdMe())


### PR DESCRIPTION
This change allows you to specify a command to view the help of.

This covers a deficiency in #90 whereby the arguments of a command are dropped from the summary.

A command without arguments looks like this:
![image](https://user-images.githubusercontent.com/42079760/137603161-5733b86d-da73-418d-a43e-711264759035.png)


A command with arguments looks like this:
![image](https://user-images.githubusercontent.com/42079760/137603165-8de9f1e5-de12-46c8-84cf-9fc9bf08174d.png)

If you specify a command that doesn't exist, it returns the help for the help command itself:
![image](https://user-images.githubusercontent.com/42079760/137603207-cfe86012-e318-4bb4-804a-fc71c1643030.png)

If no arguments are specified, it returns to the behavior i added in #90.
![image](https://user-images.githubusercontent.com/42079760/137603176-7da55ae3-2604-43f1-be92-87fe4630b4ed.png)
