### PR TITLE
Cleanup MessageUtilities

### DIFF
--- a/src/commander/java/com/mcmoddev/mmdbot/commander/TheCommander.java
+++ b/src/commander/java/com/mcmoddev/mmdbot/commander/TheCommander.java
@@ -546,17 +546,15 @@ public final class TheCommander implements Bot {
     }
 
     @Nullable
-    public RestAction<Message> getMessageByLink(final String link) throws MessageUtilities.MessageLinkException {
-        final AtomicReference<RestAction<Message>> returnAtomic = new AtomicReference<>();
-        MessageUtilities.decodeMessageLink(link, (guildId, channelId, messageId) -> {
-            final var guild = getJda().getGuildById(guildId);
-            if (guild == null) return;
-            final var channel = guild.getChannelById(MessageChannel.class, channelId);
-            if (channel != null) {
-                returnAtomic.set(channel.retrieveMessageById(messageId));
-            }
-        });
-        return returnAtomic.get();
+    public RestAction<Message> getMessageByLink(final String link) {
+        return MessageUtilities.decodeMessageLink(link)
+            .map(info -> {
+                final var guild = getJda().getGuildById(info.guildId());
+                if (guild == null) return null;
+                final var channel = guild.getChannelById(MessageChannel.class, info.channelId());
+                return channel == null ? null : channel.retrieveMessageById(info.messageId());
+            })
+            .orElse(null);
     }
 
     public String getGithubToken() {

--- a/src/commander/java/com/mcmoddev/mmdbot/commander/eventlistener/ReferencingListener.java
+++ b/src/commander/java/com/mcmoddev/mmdbot/commander/eventlistener/ReferencingListener.java
@@ -56,21 +56,14 @@ public final class ReferencingListener extends ListenerAdapter {
             return;
         }
 
-        final var matcher = MessageUtilities.MESSAGE_LINK_PATTERN.matcher(msg[0]);
-        if (matcher.find()) {
-            try {
-                final var m = TheCommander.getInstance().getMessageByLink(msg[0]);
-                if (m != null) {
-                    m.queue(message -> {
-                        event.getChannel().sendMessageEmbeds(reference(message, event.getMember())).queue();
-                        if (msg.length == 1) {
-                            originalMsg.delete().reason("Quote successful").queue();
-                        }
-                    });
+        final var m = TheCommander.getInstance().getMessageByLink(msg[0]);
+        if (m != null) {
+            m.queue(message -> {
+                event.getChannel().sendMessageEmbeds(reference(message, event.getMember())).queue();
+                if (msg.length == 1) {
+                    originalMsg.delete().reason("Quote successful").queue();
                 }
-            } catch (MessageUtilities.MessageLinkException e) {
-                // Do nothing
-            }
+            });
         }
     }
 


### PR DESCRIPTION
Removes the exception and functional interface, since their use is entirely avoidable and replaceable with normal Java conventions of return values and Optional.

Uses JDA's message jump URL pattern for robustness, instead of matching only normal (non-canary/PTB) Discord links and using manual string manipulation to obtain the IDs.