### PR TITLE
Switch moderation listeners to new audit log event

### DIFF
--- a/src/listener/java/com/mcmoddev/mmdbot/thelistener/events/ModerationEvents.java
+++ b/src/listener/java/com/mcmoddev/mmdbot/thelistener/events/ModerationEvents.java
@@ -24,32 +24,31 @@ import club.minnced.discord.webhook.send.AllowedMentions;
 import com.mcmoddev.mmdbot.core.event.moderation.WarningEvent;
 import com.mcmoddev.mmdbot.core.util.webhook.WebhookManager;
 import com.mcmoddev.mmdbot.thelistener.util.LoggingType;
-import com.mcmoddev.mmdbot.thelistener.util.Utils;
 import io.github.matyrobbrt.eventdispatcher.SubscribeEvent;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.audit.ActionType;
+import net.dv8tion.jda.api.audit.AuditLogChange;
+import net.dv8tion.jda.api.audit.AuditLogEntry;
 import net.dv8tion.jda.api.audit.AuditLogKey;
-import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.entities.channel.middleman.StandardGuildMessageChannel;
-import net.dv8tion.jda.api.events.guild.GuildBanEvent;
-import net.dv8tion.jda.api.events.guild.GuildUnbanEvent;
-import net.dv8tion.jda.api.events.guild.member.GuildMemberRemoveEvent;
-import net.dv8tion.jda.api.events.guild.member.update.GuildMemberUpdateNicknameEvent;
-import net.dv8tion.jda.api.events.guild.member.update.GuildMemberUpdateTimeOutEvent;
+import net.dv8tion.jda.api.events.guild.GuildAuditLogEntryCreateEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.utils.MarkdownSanitizer;
 import net.dv8tion.jda.api.utils.TimeFormat;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import java.awt.*;
+import java.awt.Color;
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.Optional;
+import java.time.OffsetDateTime;
 
 import static com.mcmoddev.mmdbot.thelistener.TheListener.getInstance;
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
 
 public final class ModerationEvents extends ListenerAdapter {
 
@@ -66,133 +65,143 @@ public final class ModerationEvents extends ListenerAdapter {
     }
 
     @Override
-    public void onGuildBan(@NotNull final GuildBanEvent event) {
-        Utils.getAuditLog(event.getGuild(), event.getUser().getIdLong(), log -> log
-            .limit(5)
-            .type(ActionType.BAN), log -> {
-            final var embed = new EmbedBuilder();
-            final var bannedUser = event.getUser();
-            final var bannedBy = Optional.ofNullable(log.getUser());
-            embed.setColor(Color.RED);
-            embed.setTitle("User Banned.");
-            embed.addField("**User:**", bannedUser.getAsTag(), true);
-            if (log.getReason() != null) {
-                embed.addField("**Ban reason:**", log.getReason(), false);
-            } else {
-                embed.addField("**Ban reason:**", "Reason for ban was not provided or could not be found "
-                    + "please contact a member of staff for more information about this ban ban.", false);
+    public void onGuildAuditLogEntryCreate(@NotNull final GuildAuditLogEntryCreateEvent event) {
+        final AuditLogEntry entry = event.getEntry();
+        final ActionType type = entry.getType();
+
+        switch (type) {
+            case BAN -> this.onBan(entry);
+            case UNBAN -> this.onUnban(entry);
+            case MEMBER_UPDATE -> {
+                final @Nullable AuditLogChange nicknameChange = entry.getChangeByKey(AuditLogKey.MEMBER_NICK);
+                if (nicknameChange != null) this.onNicknameUpdate(entry, nicknameChange);
+
+                final @Nullable AuditLogChange timeoutChange = entry.getChangeByKey(AuditLogKey.MEMBER_TIME_OUT);
+                if (timeoutChange != null) this.onTimeoutUpdate(entry, timeoutChange);
             }
-            embed.setFooter("User ID: " + bannedUser.getId(), bannedUser.getEffectiveAvatarUrl());
-            embed.setTimestamp(Instant.now());
-            log(event.getGuild().getIdLong(), event.getJDA(), embed.build(), bannedBy);
-        });
+            case KICK -> this.onKick(entry);
+        }
     }
 
-    @Override
-    public void onGuildUnban(@NotNull final GuildUnbanEvent event) {
-        Utils.getAuditLog(event.getGuild(), event.getUser().getIdLong(), log -> log
-            .limit(5)
-            .type(ActionType.UNBAN), log -> {
-            final var embed = new EmbedBuilder();
-            final var unBannedUser = event.getUser();
-            final var bannedBy = Optional.ofNullable(log.getUser());
-            embed.setColor(Color.GREEN);
-            embed.setTitle("User Un-banned.");
-            embed.addField("**User:**", unBannedUser.getAsTag(), true);
-            embed.setFooter("User ID: " + unBannedUser.getId(), unBannedUser.getEffectiveAvatarUrl());
-            embed.setTimestamp(Instant.now());
-            log(event.getGuild().getIdLong(), event.getJDA(), embed.build(), bannedBy);
-        });
-    }
+    public void onBan(final AuditLogEntry entry) {
+        final User bannedUser = requireNonNull(entry.getJDA().getUserById(entry.getTargetId()));
+        final User bannedBy = requireNonNull(entry.getJDA().getUserById(entry.getUserIdLong()));
+        final var reason = requireNonNullElse(entry.getReason(),
+            "_Reason for ban was not provided or could not be found; "
+                + "please contact a member of staff for more information about this ban._");
 
-    @Override
-    public void onGuildMemberUpdateNickname(@NotNull final GuildMemberUpdateNicknameEvent event) {
         final var embed = new EmbedBuilder();
-        final var targetUser = event.getUser();
+        embed.setColor(Color.RED);
+        embed.setTitle("User Banned.");
+        embed.addField("**User:**", bannedUser.getAsTag(), true);
+        embed.addField("**Ban reason:**", reason, false);
+        embed.setFooter("User ID: " + bannedUser.getId(), bannedUser.getEffectiveAvatarUrl());
+        embed.setTimestamp(Instant.now());
+
+        log(entry.getGuild().getIdLong(), entry.getJDA(), embed.build(), bannedBy);
+    }
+
+    public void onUnban(final AuditLogEntry entry) {
+        final User unBannedUser = requireNonNull(entry.getJDA().getUserById(entry.getTargetId()));
+        final User bannedBy = requireNonNull(entry.getJDA().getUserById(entry.getUserIdLong()));
+
+        final var embed = new EmbedBuilder();
+        embed.setColor(Color.GREEN);
+        embed.setTitle("User Un-banned.");
+        embed.addField("**User:**", unBannedUser.getAsTag(), true);
+        embed.setFooter("User ID: " + unBannedUser.getId(), unBannedUser.getEffectiveAvatarUrl());
+        embed.setTimestamp(Instant.now());
+
+        log(entry.getGuild().getIdLong(), entry.getJDA(), embed.build(), bannedBy);
+    }
+
+    public void onNicknameUpdate(final AuditLogEntry entry, final AuditLogChange nicknameChange) {
+        final User target = requireNonNull(entry.getJDA().getUserById(entry.getTargetId()));
+        final User editor = requireNonNull(entry.getJDA().getUserById(entry.getUserIdLong()));
+
+        final var embed = new EmbedBuilder();
         embed.setColor(Color.YELLOW);
         embed.setTitle("Nickname Changed");
-        embed.addField("User:", targetUser.getAsTag(), true);
-        embed.addField("Old Nickname:", event.getOldNickname() == null
-            ? "*None*" : event.getOldNickname(), true);
-        embed.addField("New Nickname:", event.getNewNickname() == null
-            ? "*None*" : event.getNewNickname(), true);
-        embed.setFooter("User ID: " + event.getUser().getId(), event.getUser().getEffectiveAvatarUrl());
+        embed.addField("User:", target.getAsTag(), true);
+        embed.addField("Old Nickname:", wrapNicknameValue(nicknameChange.getOldValue()), true);
+        embed.addField("New Nickname:", wrapNicknameValue(nicknameChange.getNewValue()), true);
+        embed.setFooter("User ID: " + target.getId(), target.getEffectiveAvatarUrl());
         embed.setTimestamp(Instant.now());
-        logWithWebhook(event.getGuild().getIdLong(), event.getJDA(), embed.build(), event.getUser());
+        log(entry.getGuild().getIdLong(), entry.getJDA(), embed.build(), editor);
     }
 
-    @Override
-    public void onGuildMemberRemove(@NotNull final GuildMemberRemoveEvent event) {
-        Utils.getAuditLog(event.getGuild(), event.getUser().getIdLong(), log -> log
-            .type(ActionType.KICK)
-            .limit(5), log -> {
-            if (log.getTimeCreated().toInstant().isBefore(Instant.now().minus(2, ChronoUnit.MINUTES))) {
-                return;
-            }
+    private static String wrapNicknameValue(@Nullable String nicknameValue) {
+        if (nicknameValue == null) return "*None*";
+        return MarkdownSanitizer.escape(nicknameValue);
+    }
+
+    public void onKick(final AuditLogEntry entry) {
+        final User kickedUser = requireNonNull(entry.getJDA().getUserById(entry.getTargetId()));
+        final User kicker = requireNonNull(entry.getJDA().getUserById(entry.getUserIdLong()));
+
+        final var embed = new EmbedBuilder();
+        if (kicker.isBot()) {
+            var botKickMessage = kickedUser.getAsTag() + " was kicked! Kick Reason: " + entry.getReason();
+            log(entry.getGuild().getIdLong(), entry.getJDA(), botKickMessage, kicker);
+        } else {
+            final var reason = requireNonNullElse(entry.getReason(), "Reason for kick was not provided or could not be found, please contact "
+                + "a member of staff for more information about this kick.");
+
+            embed.setColor(RUBY);
+            embed.setTitle("User Kicked");
+            embed.addField("**Name:**", kickedUser.getAsTag(), true);
+            embed.addField("**Kick reason:**", reason, false);
+            embed.setFooter("User ID: " + kickedUser.getId(), kickedUser.getAvatarUrl());
+            embed.setTimestamp(Instant.now());
+
+            log(entry.getGuild().getIdLong(), entry.getJDA(), embed.build(), kicker);
+        }
+    }
+
+    public void onTimeoutUpdate(final AuditLogEntry entry, final AuditLogChange timeoutChange) {
+        final OffsetDateTime oldTimeoutEnd = parseDateTime(timeoutChange.getOldValue());
+        final OffsetDateTime newTimeoutEnd = parseDateTime(timeoutChange.getNewValue());
+        final User user = requireNonNull(entry.getJDA().getUserById(entry.getTargetId()));
+        final User moderator = requireNonNull(entry.getJDA().getUserById(entry.getUserIdLong()));
+
+        if (oldTimeoutEnd == null && newTimeoutEnd != null) {
+            // Somebody was timed out!
+
+            final String reason = requireNonNullElse(entry.getReason(),
+                "Reason for timeout was not provided or could not be found; " +
+                    "please ask a member of staff for information about this timeout.");
 
             final var embed = new EmbedBuilder();
-            final var kicker = Optional.ofNullable(log.getUser());
-            final var kickedUser = event.getUser();
 
-            if (kicker.isPresent() && kicker.get().isBot()) {
-                var botKickMessage = kickedUser.getAsTag() + " was kicked! Kick Reason: " + log.getReason();
-                log(event.getGuild().getIdLong(), event.getJDA(), botKickMessage, kicker);
-            } else {
-                embed.setColor(RUBY);
-                embed.setTitle("User Kicked");
-                embed.addField("**Name:**", kickedUser.getAsTag(), true);
-                embed.addField("**Kick reason:**", log.getReason() != null ? log.getReason() :
-                    ("Reason for kick was not provided or could not be found, please contact "
-                        + "a member of staff for more information about this kick."), false);
-                embed.setFooter("User ID: " + kickedUser.getId(), kickedUser.getAvatarUrl());
-                embed.setTimestamp(Instant.now());
+            embed.setColor(LIGHT_SEA_GREEN);
+            embed.setTitle("User Timed Out");
+            embed.addField("**User:**", user.getAsTag(), true);
+            embed.addField("**Timeout End:**", TimeFormat.RELATIVE.format(newTimeoutEnd),
+                true);
+            embed.addField("**Reason:**", reason, false);
+            embed.setFooter("User ID: " + user.getId(), user.getEffectiveAvatarUrl());
+            embed.setTimestamp(Instant.now());
+            log(entry.getGuild().getIdLong(), entry.getJDA(), embed.build(), moderator);
 
-                log(event.getGuild().getIdLong(), event.getJDA(), embed.build(), kicker);
-            }
-        });
+        } else if (oldTimeoutEnd != null && newTimeoutEnd == null) {
+            // Somebody's timeout was removed
+            final var embed = new EmbedBuilder();
+
+            embed.setColor(Color.CYAN);
+            embed.setTitle("User Timeout Removed");
+            embed.addField("**User:**", user.getAsTag(), true);
+            embed.addField("**Old Timeout End:**", TimeFormat.RELATIVE.format(oldTimeoutEnd),
+                true);
+            embed.setFooter("User ID: " + user.getId(), user.getEffectiveAvatarUrl());
+            embed.setTimestamp(Instant.now());
+            log(entry.getGuild().getIdLong(), entry.getJDA(), embed.build(), moderator);
+
+        }
     }
 
-    @Override
-    public void onGuildMemberUpdateTimeOut(@NotNull final GuildMemberUpdateTimeOutEvent event) {
-        if (event.getOldTimeOutEnd() == null && event.getNewTimeOutEnd() != null) {
-            // Somebody was timed out!
-            Utils.getAuditLog(event.getGuild(), event.getUser().getIdLong(), log -> log.type(ActionType.MEMBER_UPDATE)
-                .limit(5), log -> {
-                if (log.getChangeByKey(AuditLogKey.MEMBER_TIME_OUT) == null) return;
-                final var embed = new EmbedBuilder();
-                final var moderator = Optional.ofNullable(log.getUser());
-                final var user = event.getUser();
-
-                embed.setColor(LIGHT_SEA_GREEN);
-                embed.setTitle("User Timed Out");
-                embed.addField("**User:**", user.getAsTag(), true);
-                embed.addField("**Timeout End:**", TimeFormat.RELATIVE.format(event.getNewTimeOutEnd()),
-                    true);
-                embed.addField("**Reason:**", log.getReason() != null ? log.getReason() :
-                    "Reason for timeout was not provided or could not be found, please ask a member of staff for "
-                        + "information about this timeout.", false);
-                embed.setFooter("User ID: " + user.getId(), user.getEffectiveAvatarUrl());
-                embed.setTimestamp(Instant.now());
-                log(event.getGuild().getIdLong(), event.getJDA(), embed.build(), moderator);
-            });
-        } else if (event.getOldTimeOutEnd() != null && event.getNewTimeOutEnd() == null) {
-            // Somebody's timeout was removed
-            Utils.getAuditLog(event.getGuild(), event.getUser().getIdLong(), log -> log.type(ActionType.MEMBER_UPDATE)
-                .limit(5), log -> {
-                if (log.getChangeByKey(AuditLogKey.MEMBER_TIME_OUT) == null) return;
-                final var embed = new EmbedBuilder();
-                final var moderator = Optional.ofNullable(log.getUser());
-                final var user = event.getUser();
-                embed.setColor(Color.CYAN);
-                embed.setTitle("User Timeout Removed");
-                embed.addField("**User:**", user.getAsTag(), true);
-                embed.addField("**Old Timeout End:**", TimeFormat.RELATIVE.format(event.getOldTimeOutEnd()),
-                    true);
-                embed.setFooter("User ID: " + user.getId(), user.getEffectiveAvatarUrl());
-                embed.setTimestamp(Instant.now());
-                log(event.getGuild().getIdLong(), event.getJDA(), embed.build(), moderator);
-            });
-        }
+    private static @Nullable OffsetDateTime parseDateTime(@Nullable String dateTimeString) {
+        if (dateTimeString == null) return null;
+        return OffsetDateTime.parse(dateTimeString);
     }
 
     @SubscribeEvent
@@ -211,7 +220,7 @@ public final class ModerationEvents extends ListenerAdapter {
                 .addField("Warning ID:", doc.warnId(), false)
                 .setFooter("User ID: " + user.getId(), user.getEffectiveAvatarUrl())
                 .setTimestamp(Instant.now());
-            logWithWebhook(event.getGuildId(), jda, embed.build(), moderator);
+            log(event.getGuildId(), jda, embed.build(), moderator);
             return null;
         }).queue();
     }
@@ -255,15 +264,6 @@ public final class ModerationEvents extends ListenerAdapter {
             });
     }
 
-    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-    private void log(long guildId, JDA jda, MessageEmbed embed, Optional<User> owner) {
-        owner.ifPresentOrElse(user -> logWithWebhook(guildId, jda, embed, user), () -> log(guildId, jda, embed));
-    }
-
-    private void log(long guildId, JDA jda, String message, Optional<User> owner) {
-        owner.ifPresentOrElse(user -> logWithWebhook(guildId, jda, message, user), () -> log(guildId, jda, message));
-    }
-
     private void log(long guildId, JDA jda, MessageEmbed embed) {
         final var loggingChannels = LoggingType.MODERATION_EVENTS.getChannels(guildId);
         loggingChannels
@@ -275,18 +275,7 @@ public final class ModerationEvents extends ListenerAdapter {
             });
     }
 
-    private void log(long guildId, JDA jda, String message) {
-        final var loggingChannels = LoggingType.MODERATION_EVENTS.getChannels(guildId);
-        loggingChannels
-            .forEach(id -> {
-                final var ch = id.resolve(idL -> jda.getChannelById(MessageChannel.class, idL));
-                if (ch != null) {
-                    ch.sendMessage(message).queue();
-                }
-            });
-    }
-
-    private void logWithWebhook(long guildId, JDA jda, MessageEmbed embed, User author) {
+    private void log(long guildId, JDA jda, MessageEmbed embed, User author) {
         final var loggingChannels = LoggingType.MODERATION_EVENTS.getChannels(guildId);
         loggingChannels
             .forEach(id -> {
@@ -301,7 +290,7 @@ public final class ModerationEvents extends ListenerAdapter {
             });
     }
 
-    private void logWithWebhook(long guildId, JDA jda, String message, User author) {
+    private void log(long guildId, JDA jda, String message, User author) {
         final var loggingChannels = LoggingType.MODERATION_EVENTS.getChannels(guildId);
         loggingChannels
             .forEach(id -> {

--- a/src/listener/java/com/mcmoddev/mmdbot/thelistener/events/RoleEvents.java
+++ b/src/listener/java/com/mcmoddev/mmdbot/thelistener/events/RoleEvents.java
@@ -136,7 +136,7 @@ public final class RoleEvents extends ListenerAdapter {
                 return null;
             })
             .queue(editor -> {
-                if (editor == null) {
+                if (editor != null) {
                     embed.addField("Editor:", editor.getAsTag(), true);
                 }
 

--- a/src/listener/java/com/mcmoddev/mmdbot/thelistener/events/RoleEvents.java
+++ b/src/listener/java/com/mcmoddev/mmdbot/thelistener/events/RoleEvents.java
@@ -23,19 +23,22 @@ package com.mcmoddev.mmdbot.thelistener.events;
 import com.mcmoddev.mmdbot.core.util.config.SnowflakeValue;
 import com.mcmoddev.mmdbot.thelistener.TheListener;
 import com.mcmoddev.mmdbot.thelistener.util.LoggingType;
-import com.mcmoddev.mmdbot.thelistener.util.Utils;
 import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.audit.ActionType;
+import net.dv8tion.jda.api.audit.AuditLogChange;
 import net.dv8tion.jda.api.audit.AuditLogEntry;
+import net.dv8tion.jda.api.audit.AuditLogKey;
 import net.dv8tion.jda.api.entities.IMentionable;
 import net.dv8tion.jda.api.entities.Member;
-import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.entities.Role;
-import net.dv8tion.jda.api.events.guild.member.GenericGuildMemberEvent;
-import net.dv8tion.jda.api.events.guild.member.GuildMemberRoleAddEvent;
-import net.dv8tion.jda.api.events.guild.member.GuildMemberRoleRemoveEvent;
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
+import net.dv8tion.jda.api.events.guild.GuildAuditLogEntryCreateEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.awt.Color;
 import java.util.ArrayList;
@@ -43,43 +46,80 @@ import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
-import static com.mcmoddev.mmdbot.thelistener.util.Utils.mentionable;
+import static java.util.Objects.requireNonNull;
 
 public final class RoleEvents extends ListenerAdapter {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RoleEvents.class);
 
     @Override
-    public void onGuildMemberRoleAdd(@NotNull final GuildMemberRoleAddEvent event) {
-        processEvent(event, "Added", event.getRoles(), List::removeAll); // Just in case if the member has already been updated with its new role list
+    public void onGuildAuditLogEntryCreate(@NotNull final GuildAuditLogEntryCreateEvent event) {
+        final AuditLogEntry entry = event.getEntry();
+        if (entry.getType() != ActionType.MEMBER_ROLE_UPDATE) return;
+
+        final @Nullable Member targetMember = event.getGuild().getMemberById(entry.getTargetIdLong());
+        if (targetMember == null) {
+            LOGGER.warn("Could not find target member with ID {} for log entry {}", entry.getTargetId(), entry);
+            return;
+        }
+
+        final List<Role> addedRoles = parseRoles(entry, AuditLogKey.MEMBER_ROLES_ADD);
+        if (!addedRoles.isEmpty()) {
+            processEvent(entry, targetMember, "Added", addedRoles, List::removeAll);
+        }
+
+        final List<Role> removedRoles = parseRoles(entry, AuditLogKey.MEMBER_ROLES_REMOVE);
+        if (!removedRoles.isEmpty()) {
+            processEvent(entry, targetMember, "Removed", removedRoles, List::addAll);
+        }
     }
 
-    @Override
-    public void onGuildMemberRoleRemove(@NotNull final GuildMemberRoleRemoveEvent event) {
-        processEvent(event, "Removed", event.getRoles(), List::addAll); // Just in case if the member has already been updated with its new role list
+    private static List<Role> parseRoles(final AuditLogEntry entry, AuditLogKey logKey) {
+        final @Nullable AuditLogChange change = entry.getChangeByKey(logKey);
+
+        if (change == null) return List.of();
+
+        // https://discord.com/developers/docs/resources/audit-log#audit-log-change-object-audit-log-change-exceptions
+        // The added/removed roles are marked in the new_value property of the audit log change
+
+        final List<String> roleIds = requireNonNull(change.getNewValue());
+        final List<Role> roles = new ArrayList<>(roleIds.size());
+        final JDA jda = entry.getJDA();
+
+        for (String roleId : roleIds) {
+            final @Nullable Role roleById = jda.getRoleById(roleId);
+            if (roleById == null) {
+                LOGGER.warn("Could not find role with ID {} while parsing change key {} for log entry {}", roleId, logKey, entry);
+                continue;
+            }
+            roles.add(roleById);
+        }
+
+        return roles;
     }
 
-    private static void processEvent(GenericGuildMemberEvent event, String changeType, List<Role> modifiedRoles,
+    private static void processEvent(AuditLogEntry entry, Member member, String changeType, List<Role> modifiedRoles,
                                      BiConsumer<List<Role>, List<Role>> roleListsConsumer) {
         // The role list consumer allows the caller to update the previous roles list with the modified roles list,
         // to guard against the case where the target's roles list has been updated before we receive the event
         // We could also check JDA's impl to see if the event always fires before the target's roles list is updated and
         // get rid of this, but :shrug:
+        final var guild = member.getGuild();
 
         final var roleIds = modifiedRoles.stream().map(Role::getIdLong).toList();
-        final var noLoggingRoles = TheListener.getInstance().getConfigForGuild(event.getGuild().getIdLong()).getNoLoggingRoles();
+        final var noLoggingRoles = TheListener.getInstance().getConfigForGuild(guild.getIdLong()).getNoLoggingRoles();
         if (noLoggingRoles.stream().map(SnowflakeValue::asLong).anyMatch(roleIds::contains)) {
             return;
         }
 
-        final List<Role> previousRoles = new ArrayList<>(event.getMember().getRoles());
+        final List<Role> previousRoles = new ArrayList<>(member.getRoles());
         roleListsConsumer.accept(previousRoles, modifiedRoles);
 
-        final var target = event.getMember();
-        Utils.getAuditLog(event.getGuild(), target.getIdLong(), log -> log.type(ActionType.MEMBER_ROLE_UPDATE).limit(5),
-            entry -> buildAndSendMessage(event, entry, target, changeType, previousRoles, modifiedRoles));
+        buildAndSendMessage(entry, member, changeType, previousRoles, modifiedRoles);
     }
 
-    private static void buildAndSendMessage(GenericGuildMemberEvent event, AuditLogEntry entry, Member target, String changeType,
+    private static void buildAndSendMessage(AuditLogEntry entry, Member target, String changeType,
                                             List<Role> previousRoles, List<Role> modifiedRoles) {
+        final var jda = target.getJDA();
         final var embed = new EmbedBuilder();
 
         embed.setTitle("User Role(s) " + changeType)
@@ -88,21 +128,16 @@ public final class RoleEvents extends ListenerAdapter {
             .setFooter("User ID: " + target.getUser().getId(), target.getEffectiveAvatarUrl())
             .setTimestamp(entry.getTimeCreated());
 
-        final var targetId = entry.getTargetIdLong();
-
-        if (targetId != target.getIdLong()) {
-            TheListener.LOGGER.warn("Inconsistency between target of retrieved audit log entry and actual role event target: " +
-                "retrieved is {}, but target is {}", targetId, target);
-        } else if (entry.getUser() != null) {
-            final var editor = entry.getUser();
+        final @Nullable var editor = jda.getUserById(entry.getUserIdLong());
+        if (editor == null) {
             embed.addField("Editor:", editor.getAsTag(), true);
         }
 
-        embed.addField("Previous Role(s):", mentionsOrEmpty(previousRoles), true);
-        embed.addField(changeType + " Role(s):", mentionsOrEmpty(modifiedRoles), true);
+        embed.addField("Previous Role(s):", mentionsOrEmpty(previousRoles), true)
+            .addField(changeType + " Role(s):", mentionsOrEmpty(modifiedRoles), true);
 
-        LoggingType.ROLE_EVENTS.getChannels(event.getGuild().getIdLong()).forEach(id -> {
-            final var ch = id.resolve(idL -> event.getJDA().getChannelById(MessageChannel.class, idL));
+        LoggingType.ROLE_EVENTS.getChannels(target.getGuild().getIdLong()).forEach(id -> {
+            final var ch = id.resolve(idL -> jda.getChannelById(MessageChannel.class, idL));
             if (ch != null) {
                 ch.sendMessageEmbeds(embed.build()).queue();
             }

--- a/src/listener/java/com/mcmoddev/mmdbot/thelistener/util/Utils.java
+++ b/src/listener/java/com/mcmoddev/mmdbot/thelistener/util/Utils.java
@@ -20,13 +20,7 @@
  */
 package com.mcmoddev.mmdbot.thelistener.util;
 
-import net.dv8tion.jda.api.audit.AuditLogEntry;
-import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.IMentionable;
-import net.dv8tion.jda.api.requests.restaction.pagination.AuditLogPaginationAction;
-
-import java.util.function.Consumer;
-import java.util.function.UnaryOperator;
 
 public final class Utils {
 
@@ -36,19 +30,6 @@ public final class Utils {
 
     public static String mentionable(final IMentionable mention) {
         return mention.getAsMention() + " (" + mention.getId() + ")";
-    }
-
-    public static void getAuditLog(final Guild guild, final long targetId, UnaryOperator<AuditLogPaginationAction> modifier, Consumer<AuditLogEntry> consumer) {
-        getAuditLog(guild, targetId, modifier, consumer, () -> {
-        });
-    }
-
-    public static void getAuditLog(final Guild guild, final long targetId, UnaryOperator<AuditLogPaginationAction> modifier, Consumer<AuditLogEntry> consumer, Runnable orElse) {
-        modifier.apply(guild.retrieveAuditLogs())
-            .queue(logs -> logs.stream()
-                .filter(entry -> entry.getTargetIdLong() == targetId)
-                .findFirst()
-                .ifPresentOrElse(consumer, orElse));
     }
 
 }


### PR DESCRIPTION
This PR switches our moderation event listeners from the various gateway events to the new audit log entry creation event.

Our previous system meant that we would have to manually query the audit log to retrieve the editor/moderator who performed the action, which is cumbersome and prone to timing issues (whether the gateway event is fired first or the audit log is updated first, and whether there are other audit log entries before the relevant one).

---

**Tasks needed to be done before merge:**
- [x] Switch to the new event in `RoleEvents`
	- This requires testing to discover what exactly the audit log change contains for roles being added or removed.
	- Additionally, what does the audit log entry look like with integration (Server Boosting) or linked roles?
- [x] Yeet `Utils#getAuditLog`
- ~~Reduce code duplication of embeds in `ModerationEvents`~~
	- There should at least be a method which prepopulates a builder which handles the common features (footer, timestamp, possibly the color as well).
	- _Not today._
- ~~Test the new functionality~~
	- _Test by fire._