### PR TITLE
Attempt to fix formatting descreprency for Forge update notifier

### DIFF
--- a/src/commander/java/com/mcmoddev/mmdbot/commander/updatenotifiers/forge/ForgeUpdateNotifier.java
+++ b/src/commander/java/com/mcmoddev/mmdbot/commander/updatenotifiers/forge/ForgeUpdateNotifier.java
@@ -145,6 +145,10 @@ public final class ForgeUpdateNotifier extends UpdateNotifier<MinecraftForgeVers
             %s.%s
             ====""".formatted(endMcVersionSplit[0], endMcVersionSplit[1], endForgeVersionSplit[0], endForgeVersionSplit[1]), "");
 
+        if (changelog.startsWith("\n")) {
+            changelog = changelog.substring(1);
+        }
+
         return changelog;
     }
 


### PR DESCRIPTION
The Forge update embed has a stray blank line, this PR attempts to fix that.

Here's a screenshot of the issue:
<img width="452" alt="image" src="https://github.com/user-attachments/assets/d700f9ea-941b-462d-8437-b5c9c366b5bf">